### PR TITLE
fix: Read data length from data type

### DIFF
--- a/src/PureHDF/VOL/Native/API.Reading/NativeDataset.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeDataset.cs
@@ -329,6 +329,8 @@ public class NativeDataset : NativeObject, IH5Dataset
             {
                 var rank = resultType.GetArrayRank();
 
+                if (rank == 1 && isRawMode && InternalDataType.Class == DatatypeMessageClass.Opaque)
+                    memoryDims ??= [InternalDataType.Size];
                 if (rank == 1)
                     memoryDims ??= [fileSelection.TotalElementCount];
 

--- a/src/PureHDF/VOL/Native/API.Reading/NativeDataset.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeDataset.cs
@@ -325,12 +325,14 @@ public class NativeDataset : NativeObject, IH5Dataset
             var resultType = typeof(TResult);
 
             /* memory dims */
-            if (DataUtils.IsArray(resultType))
+            if (isRawMode && InternalDataType.Class == DatatypeMessageClass.Opaque)
+            {
+                memoryDims ??= [InternalDataType.Size];
+            }
+            else if (DataUtils.IsArray(resultType))
             {
                 var rank = resultType.GetArrayRank();
 
-                if (rank == 1 && isRawMode && InternalDataType.Class == DatatypeMessageClass.Opaque)
-                    memoryDims ??= [InternalDataType.Size];
                 if (rank == 1)
                     memoryDims ??= [fileSelection.TotalElementCount];
 
@@ -340,7 +342,6 @@ public class NativeDataset : NativeObject, IH5Dataset
                 else
                     throw new Exception("The rank of the memory space must match the rank of the file space if no memory dimensions are provided.");
             }
-
             else
             {
                 memoryDims ??= [1];

--- a/tests/PureHDF.Tests/RoundTrip/DatasetTests@Opaque.cs
+++ b/tests/PureHDF.Tests/RoundTrip/DatasetTests@Opaque.cs
@@ -2,28 +2,32 @@ using Xunit;
 
 namespace PureHDF.Tests.RoundTrip;
 
-public class DataSetsRoundTripTests
+public class DatasetsRoundTripTests
 {
     [Fact]
     public void WriteAndReadOpaqueDataset()
     {
-        var reproducibleProblem = new H5File();
+        // Arrange
+        var h5FileWrite = new H5File();
+        var expected = new byte[] { 0x01, 0x02, 0x13 };
 
-        var data = new byte[] { 0x01, 0x02, 0x13 };
-        reproducibleProblem["test"] = new H5Dataset(data, opaqueInfo: new H5OpaqueInfo((uint) data.Length, "New"));
+        h5FileWrite["test"] = new H5Dataset(
+            data: expected, 
+            opaqueInfo: new H5OpaqueInfo((uint) expected.Length, "New")
+        );
 
         var memoryStream = new MemoryStream();
 
-        reproducibleProblem.Write(memoryStream);
+        h5FileWrite.Write(memoryStream);
         memoryStream.Seek(0, SeekOrigin.Begin);
 
-        var open = H5File.Open(memoryStream);
-        var dataset = open.Dataset("test");
+        var h5FileRead = H5File.Open(memoryStream);
+        var dataset = h5FileRead.Dataset("test");
 
-        var dataRead = dataset.Read<byte[]>();
-        Assert.True(dataRead.SequenceEqual(data));
-        // TODO: Does currently not work
-        /*var dataReadMemory = dataset.Read<Memory<byte>>();
-        Assert.True(dataReadMemory.Span.SequenceEqual(data));*/
+        // Act
+        var actual = dataset.Read<byte[]>();
+
+        // Assert
+        Assert.True(expected.SequenceEqual(actual));
     }
 }

--- a/tests/PureHDF.Tests/RoundTrip/DatasetTests@Opaque.cs
+++ b/tests/PureHDF.Tests/RoundTrip/DatasetTests@Opaque.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace PureHDF.Tests.RoundTrip;
+
+public class DataSetsRoundTripTests
+{
+    [Fact]
+    public void WriteAndReadOpaqueDataset()
+    {
+        var reproducibleProblem = new H5File();
+
+        var data = new byte[] { 0x01, 0x02, 0x13 };
+        reproducibleProblem["test"] = new H5Dataset(data, opaqueInfo: new H5OpaqueInfo((uint) data.Length, "New"));
+
+        var memoryStream = new MemoryStream();
+
+        reproducibleProblem.Write(memoryStream);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        var open = H5File.Open(memoryStream);
+        var dataset = open.Dataset("test");
+
+        var dataRead = dataset.Read<byte[]>();
+        Assert.True(dataRead.SequenceEqual(data));
+    }
+}

--- a/tests/PureHDF.Tests/RoundTrip/DatasetTests@Opaque.cs
+++ b/tests/PureHDF.Tests/RoundTrip/DatasetTests@Opaque.cs
@@ -22,5 +22,8 @@ public class DataSetsRoundTripTests
 
         var dataRead = dataset.Read<byte[]>();
         Assert.True(dataRead.SequenceEqual(data));
+        // TODO: Does currently not work
+        /*var dataReadMemory = dataset.Read<Memory<byte>>();
+        Assert.True(dataReadMemory.Span.SequenceEqual(data));*/
     }
 }


### PR DESCRIPTION
For opaque types we read the data length from the type if read as a byte array

Fixes issue #105