### PR TITLE
Don't call GetDirectoryName on empty strings

### DIFF
--- a/src/PureHDF/VOL/Native/API.Reading/NativeFile.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeFile.cs
@@ -25,7 +25,7 @@ public class NativeFile : NativeGroup, IDisposable
         bool deleteOnClose) : base(context, reference, header)
     {
         Path = absoluteFilePath;
-        FolderPath = System.IO.Path.GetDirectoryName(absoluteFilePath);
+        FolderPath = absoluteFilePath.Length > 0 ? System.IO.Path.GetDirectoryName(absoluteFilePath) : string.Empty;
         _deleteOnClose = deleteOnClose;
     }
 


### PR DESCRIPTION
since we pass empty paths when constructing from file objects.