### PR TITLE
Creation order enumeration and other changes

### DIFF
--- a/src/PureHDF/VOL/Native/API.Reading/NativeGroup.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeGroup.cs
@@ -131,6 +131,27 @@ public class NativeGroup : NativeObject, IH5Group
             .Select(reference => reference.Dereference());
     }
 
+    /// <summary>
+    /// Gets the number of children in this group without dereferencing them.
+    /// </summary>
+    /// <returns>The number of children in this group.</returns>
+    public ulong GetChildCount()
+    {
+        var linkInfoMessage = GetLinkInfoMessage();
+
+        if (!Context.Superblock.IsUndefinedAddress(linkInfoMessage.BTree2NameIndexAddress))
+        {
+            return linkInfoMessage.BTree2NameIndex.RootNodePointer.TotalRecordCount;
+        }
+
+        if (Context.Superblock.IsUndefinedAddress(linkInfoMessage.FractalHeapAddress))
+        {
+            return (ulong)Header.GetMessages<LinkMessage>().Count();
+        }
+
+        throw new NotSupportedException("The group does not use compact or indexed dense link storage.");
+    }
+
     private bool InternalLinkExists(string path, H5LinkAccess linkAccess)
     {
         if (path == "/")
@@ -430,7 +451,16 @@ public class NativeGroup : NativeObject, IH5Group
                      * A group is storing its links compactly when the fractal heap address 
                      * in the Link Info Message is set to the "undefined address" value. */
                     else
+                    {
                         linkMessages = Header.GetMessages<LinkMessage>();
+
+                        if (lmessage.Flags.HasFlag(CreationOrderFlags.TrackCreationOrder))
+                        {
+                            linkMessages = linkMessages
+                                .OrderBy(message => message.CreationOrder)
+                                .ToList();
+                        }
+                    }
 
                     // build links
                     foreach (var linkMessage in linkMessages)
@@ -452,6 +482,14 @@ public class NativeGroup : NativeObject, IH5Group
 
     private IEnumerable<LinkMessage> EnumerateLinkMessagesFromLinkInfoMessage(LinkInfoMessage infoMessage)
     {
+        if (infoMessage.Flags.HasFlag(CreationOrderFlags.TrackCreationOrder))
+            return EnumerateLinkMessagesByCreationOrder(infoMessage);
+
+        return EnumerateLinkMessagesByName(infoMessage);
+    }
+
+    private IEnumerable<LinkMessage> EnumerateLinkMessagesByName(LinkInfoMessage infoMessage)
+    {
         var fractalHeap = infoMessage.FractalHeap;
         var btree2NameIndex = infoMessage.BTree2NameIndex;
         var records = btree2NameIndex
@@ -463,15 +501,58 @@ public class NativeGroup : NativeObject, IH5Group
 
         foreach (var record in records)
         {
-            using var localDriver = new H5StreamDriver(new MemoryStream(record.HeapId), leaveOpen: false);
-            var heapId = FractalHeapId.Construct(Context, localDriver, fractalHeap);
-
-            yield return heapId.Read(driver =>
-            {
-                var message = LinkMessage.Decode(Context);
-                return message;
-            }, ref record01Cache);
+            yield return ReadLinkMessage(fractalHeap, record.HeapId, ref record01Cache);
         }
+    }
+
+    private IEnumerable<LinkMessage> EnumerateLinkMessagesByCreationOrder(LinkInfoMessage infoMessage)
+    {
+        if (Context.Superblock.IsUndefinedAddress(infoMessage.BTree2CreationOrderIndexAddress))
+        {
+            return EnumerateLinkMessagesByName(infoMessage)
+                .OrderBy(message => message.CreationOrder)
+                .ToList();
+        }
+
+        return EnumerateLinkMessagesByCreationOrderIndex(infoMessage);
+    }
+
+    private IEnumerable<LinkMessage> EnumerateLinkMessagesByCreationOrderIndex(LinkInfoMessage infoMessage)
+    {
+        var fractalHeap = infoMessage.FractalHeap;
+        var btree2CreationOrder = infoMessage.BTree2CreationOrder;
+        var records = btree2CreationOrder
+            .EnumerateRecords()
+            .ToList();
+
+        // local cache: indirectly accessed, non-filtered
+        List<BTree2Record01>? record01Cache = null;
+
+        foreach (var record in records)
+        {
+            yield return ReadLinkMessage(fractalHeap, record.HeapId, ref record01Cache);
+        }
+    }
+
+    private LinkInfoMessage GetLinkInfoMessage()
+    {
+        var linkInfoMessages = Header.GetMessages<LinkInfoMessage>();
+
+        if (!linkInfoMessages.Any())
+            throw new Exception("No link information found in object header.");
+
+        if (linkInfoMessages.Count() != 1)
+            throw new Exception("There may be only a single link info message.");
+
+        return linkInfoMessages.First();
+    }
+
+    private LinkMessage ReadLinkMessage(FractalHeapHeader fractalHeap, byte[] heapIdBytes, ref List<BTree2Record01>? record01Cache)
+    {
+        using var localDriver = new H5StreamDriver(new MemoryStream(heapIdBytes), leaveOpen: false);
+        var heapId = FractalHeapId.Construct(Context, localDriver, fractalHeap);
+
+        return heapId.Read(driver => LinkMessage.Decode(Context), ref record01Cache);
     }
 
     private bool TryGetLinkMessageFromLinkInfoMessage(LinkInfoMessage linkInfoMessage,

--- a/src/PureHDF/VOL/Native/API.Reading/NativeGroup.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeGroup.cs
@@ -457,8 +457,7 @@ public class NativeGroup : NativeObject, IH5Group
                         if (lmessage.Flags.HasFlag(CreationOrderFlags.TrackCreationOrder))
                         {
                             linkMessages = linkMessages
-                                .OrderBy(message => message.CreationOrder)
-                                .ToList();
+                                .OrderBy(message => message.CreationOrder);
                         }
                     }
 
@@ -492,14 +491,11 @@ public class NativeGroup : NativeObject, IH5Group
     {
         var fractalHeap = infoMessage.FractalHeap;
         var btree2NameIndex = infoMessage.BTree2NameIndex;
-        var records = btree2NameIndex
-            .EnumerateRecords()
-            .ToList();
 
         // local cache: indirectly accessed, non-filtered
-        List<BTree2Record01>? record01Cache = null;
+        BTree2Header<BTree2Record01>? record01Cache = null;
 
-        foreach (var record in records)
+        foreach (var record in btree2NameIndex.EnumerateRecords())
         {
             yield return ReadLinkMessage(fractalHeap, record.HeapId, ref record01Cache);
         }
@@ -510,8 +506,7 @@ public class NativeGroup : NativeObject, IH5Group
         if (Context.Superblock.IsUndefinedAddress(infoMessage.BTree2CreationOrderIndexAddress))
         {
             return EnumerateLinkMessagesByName(infoMessage)
-                .OrderBy(message => message.CreationOrder)
-                .ToList();
+                .OrderBy(message => message.CreationOrder);
         }
 
         return EnumerateLinkMessagesByCreationOrderIndex(infoMessage);
@@ -521,14 +516,11 @@ public class NativeGroup : NativeObject, IH5Group
     {
         var fractalHeap = infoMessage.FractalHeap;
         var btree2CreationOrder = infoMessage.BTree2CreationOrder;
-        var records = btree2CreationOrder
-            .EnumerateRecords()
-            .ToList();
 
         // local cache: indirectly accessed, non-filtered
-        List<BTree2Record01>? record01Cache = null;
+        BTree2Header<BTree2Record01>? record01Cache = null;
 
-        foreach (var record in records)
+        foreach (var record in btree2CreationOrder.EnumerateRecords())
         {
             yield return ReadLinkMessage(fractalHeap, record.HeapId, ref record01Cache);
         }
@@ -547,7 +539,7 @@ public class NativeGroup : NativeObject, IH5Group
         return linkInfoMessages.First();
     }
 
-    private LinkMessage ReadLinkMessage(FractalHeapHeader fractalHeap, byte[] heapIdBytes, ref List<BTree2Record01>? record01Cache)
+    private LinkMessage ReadLinkMessage(FractalHeapHeader fractalHeap, byte[] heapIdBytes, ref BTree2Header<BTree2Record01>? record01Cache)
     {
         using var localDriver = new H5StreamDriver(new MemoryStream(heapIdBytes), leaveOpen: false);
         var heapId = FractalHeapId.Construct(Context, localDriver, fractalHeap);

--- a/src/PureHDF/VOL/Native/API.Reading/NativeObject.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeObject.cs
@@ -186,16 +186,13 @@ public abstract class NativeObject : IH5Object
         AttributeInfoMessage attributeInfoMessage)
     {
         var btree2NameIndex = attributeInfoMessage.BTree2NameIndex;
-        var records = btree2NameIndex
-            .EnumerateRecords()
-            .ToList();
 
         var fractalHeap = attributeInfoMessage.FractalHeap;
 
         // local cache: indirectly accessed, non-filtered
-        List<BTree2Record01>? record01Cache = null;
+        BTree2Header<BTree2Record01>? record01Cache = null;
 
-        foreach (var record in records)
+        foreach (var record in btree2NameIndex.EnumerateRecords())
         {
             // TODO: duplicate1_of_3
             using var localDriver = new H5StreamDriver(new MemoryStream(record.HeapId), leaveOpen: false);

--- a/src/PureHDF/VOL/Native/Core.Reading/NativeCache.cs
+++ b/src/PureHDF/VOL/Native/Core.Reading/NativeCache.cs
@@ -8,8 +8,8 @@ internal static class NativeCache
 
     static NativeCache()
     {
-        _globalHeapMap = new ConcurrentDictionary<H5DriverBase, Dictionary<ulong, GlobalHeapCollection>>();
-        _fileMap = new ConcurrentDictionary<H5DriverBase, Dictionary<string, NativeFile>>();
+        _globalHeapMap = new ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<ulong, GlobalHeapCollection>>();
+        _fileMap = new ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<string, NativeFile>>();
     }
 
     #endregion
@@ -41,7 +41,7 @@ internal static class NativeCache
 
     #region Global Heap
 
-    private static readonly ConcurrentDictionary<H5DriverBase, Dictionary<ulong, GlobalHeapCollection>> _globalHeapMap;
+    private static readonly ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<ulong, GlobalHeapCollection>> _globalHeapMap;
 
     public static GlobalHeapCollection GetGlobalHeapObject(
         NativeReadContext context,
@@ -50,8 +50,8 @@ internal static class NativeCache
     {
         if (!_globalHeapMap.TryGetValue(context.Driver, out var addressToCollectionMap))
         {
-            addressToCollectionMap = new Dictionary<ulong, GlobalHeapCollection>();
-            _globalHeapMap.AddOrUpdate(context.Driver, addressToCollectionMap, (_, oldAddressToCollectionMap) => addressToCollectionMap);
+            addressToCollectionMap = new ConcurrentDictionary<ulong, GlobalHeapCollection>();
+            _globalHeapMap.AddOrUpdate(context.Driver, addressToCollectionMap, (_, oldAddressToCollectionMap) => oldAddressToCollectionMap);
         }
 
         if (!addressToCollectionMap.TryGetValue(address, out var collection))
@@ -74,7 +74,7 @@ internal static class NativeCache
 
     #region File Handles
 
-    private static readonly ConcurrentDictionary<H5DriverBase, Dictionary<string, NativeFile>> _fileMap;
+    private static readonly ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<string, NativeFile>> _fileMap;
 
     public static NativeFile GetNativeFile(H5DriverBase driver, string absoluteFilePath)
     {
@@ -86,8 +86,8 @@ internal static class NativeCache
 
         if (!_fileMap.TryGetValue(driver, out var pathToNativeFileMap))
         {
-            pathToNativeFileMap = new Dictionary<string, NativeFile>();
-            _fileMap.AddOrUpdate(driver, pathToNativeFileMap, (_, oldPathToNativeFileMap) => pathToNativeFileMap);
+            pathToNativeFileMap = new ConcurrentDictionary<string, NativeFile>();
+            _fileMap.AddOrUpdate(driver, pathToNativeFileMap, (_, oldPathToNativeFileMap) => oldPathToNativeFileMap);
         }
 
         if (!pathToNativeFileMap.TryGetValue(uri.AbsoluteUri, out var nativeFile))

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/BTree2/BTree2Header.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/BTree2/BTree2Header.cs
@@ -283,7 +283,7 @@ internal record class BTree2Header<T>(
             return EnumerateRecords(rootNode, Depth);
 
         else
-            return new List<T>();
+            return Enumerable.Empty<T>();
     }
 
     private IEnumerable<T> EnumerateRecords(BTree2Node<T> node, ushort nodeLevel)
@@ -296,9 +296,7 @@ internal record class BTree2Header<T>(
 
         if (internalNode is not null)
         {
-            var records = node.Records
-                .Cast<T>()
-                .ToList();
+            var records = internalNode.Records;
 
             var nodePointers = internalNode.NodePointers;
 
@@ -339,7 +337,7 @@ internal record class BTree2Header<T>(
                 }
 
                 // there is one more node pointer than records
-                if (i < records.Count)
+                if (i < records.Length)
                     yield return records[i];
             }
         }

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/BTree2/BTree2Header.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/BTree2/BTree2Header.cs
@@ -304,10 +304,6 @@ internal record class BTree2Header<T>(
 
             for (int i = 0; i < nodePointers.Length; i++)
             {
-                // there is one more node pointer than records
-                if (i < records.Count)
-                    yield return records[i];
-
                 var nodePointer = nodePointers[i];
                 Context.Driver.SeekRelativeToBaseAddress((long)nodePointer.Address);
                 var childNodeLevel = (ushort)(nodeLevel - 1);
@@ -341,6 +337,10 @@ internal record class BTree2Header<T>(
                 {
                     yield return record;
                 }
+
+                // there is one more node pointer than records
+                if (i < records.Count)
+                    yield return records[i];
             }
         }
         // leaf node

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/FractalHeapId.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/FractalHeapId.cs
@@ -50,11 +50,11 @@ internal abstract record class FractalHeapId(
     public T Read<T>(Func<H5DriverBase, T> func)
     {
         // TODO: Is there a better way?
-        List<BTree2Record01>? cache = null;
+        BTree2Header<BTree2Record01>? cache = null;
         return Read(func, ref cache);
     }
 
     public abstract T Read<T>(
         Func<H5DriverBase, T> func,
-        [AllowNull] ref List<BTree2Record01> record01Cache);
+        [AllowNull] ref BTree2Header<BTree2Record01> record01Cache);
 }

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType1.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType1.cs
@@ -23,7 +23,7 @@ internal record class HugeObjectsFractalHeapIdSubType1(
 
     public override T Read<T>(
         Func<H5DriverBase, T> func,
-        [AllowNull] ref List<BTree2Record01> record01Cache)
+        [AllowNull] ref BTree2Header<BTree2Record01> record01Cache)
     {
         var driver = Context.Driver;
 
@@ -31,11 +31,14 @@ internal record class HugeObjectsFractalHeapIdSubType1(
         if (record01Cache is null)
         {
             driver.SeekRelativeToBaseAddress((long)HeapHeader.HugeObjectsBTree2Address);
-            var hugeBtree2 = BTree2Header<BTree2Record01>.Decode(Context, DecodeRecord01);
-            record01Cache = hugeBtree2.EnumerateRecords().ToList();
+            record01Cache = BTree2Header<BTree2Record01>.Decode(Context, DecodeRecord01);
         }
 
-        var hugeRecord = record01Cache.FirstOrDefault(record => record.HugeObjectId == BTree2Key);
+        var success = record01Cache.TryFindRecord(out var hugeRecord, record => BTree2Key.CompareTo(record.HugeObjectId));
+
+        if (!success)
+            throw new Exception("Could not find huge fractal heap object.");
+
         driver.SeekRelativeToBaseAddress((long)hugeRecord.HugeObjectAddress);
 
         return func(driver);

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType2.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType2.cs
@@ -22,7 +22,7 @@ internal record class HugeObjectsFractalHeapIdSubType2(
 
     public override T Read<T>(
         Func<H5DriverBase, T> func,
-        [AllowNull] ref List<BTree2Record01> record01Cache)
+        [AllowNull] ref BTree2Header<BTree2Record01> record01Cache)
     {
         throw new Exception("Filtered data is not yet supported.");
     }

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType3.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType3.cs
@@ -20,7 +20,7 @@ internal record class HugeObjectsFractalHeapIdSubType3(
     }
     public override T Read<T>(
         Func<H5DriverBase, T> func,
-        [AllowNull] ref List<BTree2Record01> record01Cache)
+        [AllowNull] ref BTree2Header<BTree2Record01> record01Cache)
     {
         Driver.SeekRelativeToBaseAddress((long)Address);
         return func(Driver);

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType4.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/HugeObjectsFractalHeapIdSubType4.cs
@@ -23,7 +23,7 @@ internal record class HugeObjectsFractalHeapIdSubType4(
 
     public override T Read<T>(
         Func<H5DriverBase, T> func,
-        [AllowNull] ref List<BTree2Record01> record01Cache)
+        [AllowNull] ref BTree2Header<BTree2Record01> record01Cache)
     {
         throw new Exception("Filtered data is not yet supported.");
     }

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/ManagedObjectsFractalHeapId.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/ManagedObjectsFractalHeapId.cs
@@ -26,7 +26,7 @@ internal record class ManagedObjectsFractalHeapId(
 
     public override T Read<T>(
         Func<H5DriverBase, T> func,
-        [AllowNull] ref List<BTree2Record01> record01Cache)
+        [AllowNull] ref BTree2Header<BTree2Record01> record01Cache)
     {
         var address = Header.GetAddress(this);
 

--- a/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/TinyObjectsFractalHeapIdSubType1.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level1/FractalHeap/FractalHeapId/TinyObjectsFractalHeapIdSubType1.cs
@@ -19,7 +19,7 @@ internal record class TinyObjectsFractalHeapIdSubType1(
 
     public override T Read<T>(
         Func<H5DriverBase, T> func,
-        [AllowNull] ref List<BTree2Record01> record01Cache)
+        [AllowNull] ref BTree2Header<BTree2Record01> record01Cache)
     {
         using var driver = new H5StreamDriver(new MemoryStream(Data), leaveOpen: false);
         return func.Invoke(driver);

--- a/tests/PureHDF.Tests/Reading/LinkTests.cs
+++ b/tests/PureHDF.Tests/Reading/LinkTests.cs
@@ -1,5 +1,6 @@
 using HDF.PInvoke;
 using PureHDF.VFD;
+using System.Text;
 using Xunit;
 
 namespace PureHDF.Tests.Reading;
@@ -98,6 +99,29 @@ public class LinkTests
             var actual = group.Children().Count();
             Assert.Equal(expected, actual);
         });
+    }
+
+    [Fact]
+    public void CanEnumerateDenseIndexedChildrenInNameIndexOrder()
+    {
+        // Arrange
+        const int childCount = 1000;
+        var filePath = TestUtils.PrepareTestFile(H5F.libver_t.V110, fileId => TestUtils.AddMassLinks(fileId));
+
+        // Act
+        using var root = NativeFile.InternalOpenRead(filePath, deleteOnClose: true);
+        var group = root.Group("mass_links");
+        var actual = group.Children();
+
+        var expected = Enumerable
+            .Range(0, childCount)
+            .Select(index => $"mass_{index:D4}")
+            .OrderBy(name => ChecksumUtils.JenkinsLookup3(Encoding.UTF8.GetBytes(name)))
+            .ThenBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        // Assert
+        Assert.Equal(expected, actual.Select(child => child.Name));
     }
 
     [Fact]

--- a/tests/PureHDF.Tests/Reading/LinkTests.cs
+++ b/tests/PureHDF.Tests/Reading/LinkTests.cs
@@ -125,6 +125,80 @@ public class LinkTests
     }
 
     [Fact]
+    public void CanCountDenseIndexedChildren()
+    {
+        // Arrange
+        const int childCount = 32;
+        var filePath = TestUtils.PrepareTestFile(H5F.libver_t.V110, fileId => TestUtils.AddCreationOrderIndexedLinks(fileId, childCount));
+
+        // Act
+        using var root = NativeFile.InternalOpenRead(filePath, deleteOnClose: true);
+        var group = (NativeGroup)root.Group("creation_order_links");
+        var actual = group.GetChildCount();
+
+        // Assert
+        Assert.Equal((ulong)childCount, actual);
+    }
+
+    [Fact]
+    public void CanCountCompactChildren()
+    {
+        // Arrange
+        const int childCount = 4;
+        var filePath = TestUtils.PrepareTestFile(H5F.libver_t.V110, fileId => TestUtils.AddCreationOrderIndexedLinks(fileId, childCount));
+
+        // Act
+        using var root = NativeFile.InternalOpenRead(filePath, deleteOnClose: true);
+        var group = (NativeGroup)root.Group("creation_order_links");
+        var actual = group.GetChildCount();
+
+        // Assert
+        Assert.Equal((ulong)childCount, actual);
+    }
+
+    [Fact]
+    public void CanEnumerateDenseIndexedChildrenInCreationOrder()
+    {
+        // Arrange
+        const int childCount = 128;
+        var filePath = TestUtils.PrepareTestFile(H5F.libver_t.V110, fileId => TestUtils.AddCreationOrderIndexedLinks(fileId, childCount));
+
+        // Act
+        using var root = NativeFile.InternalOpenRead(filePath, deleteOnClose: true);
+        var group = (NativeGroup)root.Group("creation_order_links");
+        var actual = group.Children();
+
+        var expected = Enumerable
+            .Range(0, childCount)
+            .Select(index => $"child_{childCount - index:D4}")
+            .ToArray();
+
+        // Assert
+        Assert.Equal(expected, actual.Select(child => child.Name));
+    }
+
+    [Fact]
+    public void CanEnumerateCompactChildrenInCreationOrder()
+    {
+        // Arrange
+        const int childCount = 4;
+        var filePath = TestUtils.PrepareTestFile(H5F.libver_t.V110, fileId => TestUtils.AddCreationOrderIndexedLinks(fileId, childCount));
+
+        // Act
+        using var root = NativeFile.InternalOpenRead(filePath, deleteOnClose: true);
+        var group = (NativeGroup)root.Group("creation_order_links");
+        var actual = group.Children().Take(2);
+
+        var expected = Enumerable
+            .Range(0, 2)
+            .Select(index => $"child_{childCount - index:D4}")
+            .ToArray();
+
+        // Assert
+        Assert.Equal(expected, actual.Select(child => child.Name));
+    }
+
+    [Fact]
     public void CanOpenDataset_DataLayoutMessage12()
     {
         /* We use a simple binary file which encodes a data layout message because 

--- a/tests/PureHDF.Tests/TestUtils/TestUtils@links.cs
+++ b/tests/PureHDF.Tests/TestUtils/TestUtils@links.cs
@@ -53,6 +53,33 @@ public partial class TestUtils
         _ = H5G.close(groupId);
     }
 
+    public static unsafe void AddCreationOrderIndexedLinks(long fileId, int count = 32)
+    {
+        var gcplId = H5P.create(H5P.GROUP_CREATE);
+        var flags = H5P.CRT_ORDER_TRACKED | H5P.CRT_ORDER_INDEXED;
+
+        if (H5P.set_link_creation_order(gcplId, flags) < 0)
+            throw new Exception("Could not enable link creation-order tracking and indexing.");
+
+        var groupId = H5G.create(fileId, "creation_order_links", 0, gcplId, 0);
+
+        if (groupId < 0)
+            throw new Exception("Could not create creation-order indexed group.");
+
+        for (int i = 0; i < count; i++)
+        {
+            var linkId = H5G.create(groupId, $"child_{count - i:D4}");
+
+            if (linkId < 0)
+                throw new Exception("Could not create child group.");
+
+            _ = H5G.close(linkId);
+        }
+
+        _ = H5G.close(groupId);
+        _ = H5P.close(gcplId);
+    }
+
     public static unsafe void AddLinks(long fileId)
     {
         var groupId = H5G.create(fileId, "links");


### PR DESCRIPTION
Hi @Apollo3zehn in our tool we need to iterate lazily through children in creation order. I tasked AI with implementing this and the results (with some tidy up by myself) are in this PR.

It appears to be working well for us, but I haven't thoroughly tested it yet.

Let me know if you're interested in some, or all, of these commits and I'll tidy it up a bit more (if needed).