### PR TITLE
Make tests runnable on Windows and with newer h5dump, with related fixes

### DIFF
--- a/benchmarks/PureHDF.Benchmarks/PureHDF.Benchmarks.csproj
+++ b/benchmarks/PureHDF.Benchmarks/PureHDF.Benchmarks.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.13-nightly.20240519.155" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Intrinsics.ISA-L.PInvoke" Version="2.30.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>

--- a/benchmarks/PureHDF.Benchmarks/Shuffle.cs
+++ b/benchmarks/PureHDF.Benchmarks/Shuffle.cs
@@ -35,8 +35,8 @@ public class Shuffle
 
         ShuffleAvx2.DoShuffle(
             _bytesOfType,
-            MemoryMarshal.AsBytes<long>(source),
-            MemoryMarshal.AsBytes<long>(destination));
+            MemoryMarshal.AsBytes<long>(source.AsSpan()),
+            MemoryMarshal.AsBytes<long>(destination.AsSpan()));
 
         _shuffledData = destination;
 
@@ -54,8 +54,8 @@ public class Shuffle
     {
         ShuffleGeneric.DoUnshuffle(
             _bytesOfType,
-            MemoryMarshal.AsBytes<long>(_shuffledData),
-            MemoryMarshal.AsBytes<long>(_unshuffledData));
+            MemoryMarshal.AsBytes<long>(_shuffledData.AsSpan()),
+            MemoryMarshal.AsBytes<long>(_unshuffledData.AsSpan()));
 
         return _unshuffledData;
     }
@@ -65,8 +65,8 @@ public class Shuffle
     {
         ShuffleSse2.DoUnshuffle(
             _bytesOfType,
-            MemoryMarshal.AsBytes<long>(_shuffledData),
-            MemoryMarshal.AsBytes<long>(_unshuffledData));
+            MemoryMarshal.AsBytes<long>(_shuffledData.AsSpan()),
+            MemoryMarshal.AsBytes<long>(_unshuffledData.AsSpan()));
 
         return _unshuffledData;
     }
@@ -76,8 +76,8 @@ public class Shuffle
     {
         ShuffleAvx2.DoUnshuffle(
             _bytesOfType,
-            MemoryMarshal.AsBytes<long>(_shuffledData),
-            MemoryMarshal.AsBytes<long>(_unshuffledData));
+            MemoryMarshal.AsBytes<long>(_shuffledData.AsSpan()),
+            MemoryMarshal.AsBytes<long>(_unshuffledData.AsSpan()));
 
         return _unshuffledData;
     }

--- a/src/PureHDF/Utils/FilePathUtils.cs
+++ b/src/PureHDF/Utils/FilePathUtils.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace PureHDF;
 
 internal static class FilePathUtils
@@ -77,24 +75,13 @@ internal static class FilePathUtils
 
         if (envVariable is not null)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // Path.PathSeparator is ':' on Unix and ';' on Windows
+            foreach (var envPrefix in envVariable.Split(Path.PathSeparator))
             {
-                var envResult = Path.Combine(envVariable, filePath);
+                var envResult = Path.Combine(envPrefix, filePath);
 
                 if (fileExists(envResult))
                     return envResult;
-            }
-            else
-            {
-                var envPrefixes = envVariable.Split(':');
-
-                foreach (var envPrefix in envPrefixes)
-                {
-                    var envResult = Path.Combine(envPrefix, filePath);
-
-                    if (fileExists(envResult))
-                        return envResult;
-                }
             }
         }
 
@@ -157,15 +144,21 @@ internal static class FilePathUtils
 
         if (envVariable is not null)
         {
-            if (envVariable.StartsWith(ORIGIN_TOKEN) && thisFolderPath is not null)
-                envVariable = Path.Combine(
-                    thisFolderPath,
-                    envVariable[ORIGIN_TOKEN.Length..]);
+            // Path.PathSeparator is ':' on Unix and ';' on Windows.
+            foreach (var rawPrefix in envVariable.Split(Path.PathSeparator))
+            {
+                var envPrefix = rawPrefix;
 
-            var envResult = Path.Combine(envVariable, filePath);
+                if (envPrefix.StartsWith(ORIGIN_TOKEN) && thisFolderPath is not null)
+                    envPrefix = Path.Combine(
+                        thisFolderPath,
+                        envPrefix[ORIGIN_TOKEN.Length..]);
 
-            if (fileExists(envResult))
-                return envResult;
+                var envResult = Path.Combine(envPrefix, filePath);
+
+                if (fileExists(envResult))
+                    return envResult;
+            }
         }
 
         // 2. dataset access property list

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/StoragePropertyDescriptions.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/StoragePropertyDescriptions.cs
@@ -200,6 +200,11 @@ internal record class ChunkedStoragePropertyDescription4(
     // dimension-size encoded length is not the minimum number of bytes
     // needed to encode the largest dimension. 1.14.x accepted any
     // self-consistent value.
+    //
+    // This issue is already solved in the C-library and it now behaves
+    // according to the spec (https://github.com/HDFGroup/hdf5/issues/6409)
+    // but it still make sense to minimize required amount of bytes to
+    // encode the dimension size.
     private byte GetDimensionSizeEncodedLength()
     {
         var maxDimensionSize = 1UL;

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/StoragePropertyDescriptions.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/StoragePropertyDescriptions.cs
@@ -1,4 +1,6 @@
-﻿namespace PureHDF.VOL.Native;
+﻿using System.Numerics;
+
+namespace PureHDF.VOL.Native;
 
 internal abstract record class StoragePropertyDescription(
 //
@@ -194,13 +196,32 @@ internal record class ChunkedStoragePropertyDescription4(
         };
     }
 
+    // HDF5 2.1.x rejects the file at H5Dchunk.c:859 if the stored
+    // dimension-size encoded length is not the minimum number of bytes
+    // needed to encode the largest dimension. 1.14.x accepted any
+    // self-consistent value.
+    private byte GetDimensionSizeEncodedLength()
+    {
+        var maxDimensionSize = 1UL;
+
+        for (var i = 0; i < Rank; i++)
+        {
+            if (DimensionSizes[i] > maxDimensionSize)
+                maxDimensionSize = DimensionSizes[i];
+        }
+
+        return (byte)((BitOperations.Log2(maxDimensionSize) / 8) + 1);
+    }
+
     public override ushort GetEncodeSize()
     {
+        var dimensionSizeEncodedLength = GetDimensionSizeEncodedLength();
+
         var encodeSize =
             sizeof(byte) +
             sizeof(byte) +
             sizeof(byte) +
-            sizeof(ulong) * Rank +
+            dimensionSizeEncodedLength * Rank +
             sizeof(byte) +
             IndexingInformation.GetEncodeSize(Flags) +
             sizeof(ulong);
@@ -219,15 +240,15 @@ internal record class ChunkedStoragePropertyDescription4(
         driver.Write(Rank);
 
         // dimension size encoded length
-        driver.Write((byte)8);
+        var dimensionSizeEncodedLength = GetDimensionSizeEncodedLength();
+        driver.Write(dimensionSizeEncodedLength);
 
-        // dimension sizes
-        for (int i = 0; i < Rank - 1; i++)
+        // dimension sizes (chunk dims, then the element-size pseudo-dim
+        // already set by DataLayoutMessage4.Create)
+        for (var i = 0; i < Rank; i++)
         {
-            driver.Write(DimensionSizes[i]);
+            WriteUtils.WriteUlongArbitrary(driver, DimensionSizes[i], dimensionSizeEncodedLength);
         }
-
-        driver.Write((ulong)4);
 
         // chunk indexing type
         var indexingType = IndexingInformation switch

--- a/src/PureHDF/VOL/Native/H5D/H5D_Virtual.cs
+++ b/src/PureHDF/VOL/Native/H5D/H5D_Virtual.cs
@@ -8,6 +8,12 @@ internal class H5D_Virtual<TResult> : H5D_Base
     private readonly TResult? _fillValue;
     private readonly ReadVirtualDelegate<TResult> _readVirtualDelegate;
 
+    // The stream owns the cache of opened source files (one per VdsDatasetEntry).
+    // We create it lazily on first GetReadStream call and tie its lifetime to
+    // this instance, so the source-file handles are released when
+    // we're disposed.
+    private VirtualDatasetStream<TResult>? _stream;
+
     #endregion
 
     #region Constructors
@@ -61,7 +67,7 @@ internal class H5D_Virtual<TResult> : H5D_Base
 
     public override IH5ReadStream GetReadStream(ulong chunkIndex)
     {
-        IH5ReadStream stream = new VirtualDatasetStream<TResult>(
+        _stream ??= new VirtualDatasetStream<TResult>(
             ReadContext.File,
             _block.VdsDatasetEntries,
             dimensions: Dataset.Space.Dimensions,
@@ -70,12 +76,23 @@ internal class H5D_Virtual<TResult> : H5D_Base
             _readVirtualDelegate
         );
 
-        return stream;
+        return _stream;
     }
 
     public override IH5WriteStream GetWriteStream(ulong chunkIndex)
     {
         throw new NotImplementedException();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            _stream?.Dispose();
+            _stream = null;
+        }
     }
 
     #endregion

--- a/tests/PureHDF.SourceGenerator.Tests/PureHDF.SourceGenerator.Tests.csproj
+++ b/tests/PureHDF.SourceGenerator.Tests/PureHDF.SourceGenerator.Tests.csproj
@@ -8,8 +8,8 @@
  
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/PureHDF.Tests/DumpFiles/data_DataspaceMessage.dump
+++ b/tests/PureHDF.Tests/DumpFiles/data_DataspaceMessage.dump
@@ -35,10 +35,3 @@ GROUP "/" {
    }
 }
 }
-HDF5-DIAG: Error detected in HDF5 (1.14.4-2) thread 0:
-  #000: /home/runner/work/hdf5/hdf5/hdf5-1.14.4-2/src/H5Tenum.c line 306 in H5Tenum_nameof(): nameof query failed
-    major: Datatype
-    minor: Unable to initialize object
-  #001: /home/runner/work/hdf5/hdf5/hdf5-1.14.4-2/src/H5Tenum.c line 378 in H5T__enum_nameof(): value is currently not defined
-    major: Datatype
-    minor: Object not found

--- a/tests/PureHDF.Tests/DumpFiles/data_large_array.dump
+++ b/tests/PureHDF.Tests/DumpFiles/data_large_array.dump
@@ -84,10 +84,3 @@ GROUP "/" {
    }
 }
 }
-HDF5-DIAG: Error detected in HDF5 (1.14.4-2) thread 0:
-  #000: /home/runner/work/hdf5/hdf5/hdf5-1.14.4-2/src/H5Tenum.c line 306 in H5Tenum_nameof(): nameof query failed
-    major: Datatype
-    minor: Unable to initialize object
-  #001: /home/runner/work/hdf5/hdf5/hdf5-1.14.4-2/src/H5Tenum.c line 378 in H5T__enum_nameof(): value is currently not defined
-    major: Datatype
-    minor: Object not found

--- a/tests/PureHDF.Tests/Filters/FilterTests.cs
+++ b/tests/PureHDF.Tests/Filters/FilterTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace PureHDF.Tests.Filters;
 
+[Collection(PureHDF.Tests.SharedHdf5StateCollection.Name)]
 public class FilterTests
 {
     [Theory]
@@ -170,7 +171,7 @@ public class FilterTests
         // Assert
         try
         {
-            var h5File = H5File.OpenRead(filePath);
+            using var h5File = H5File.OpenRead(filePath);
             var dataset = h5File.Dataset("filtered");
             var actual = dataset.Read<int[]>();
 
@@ -267,7 +268,7 @@ public class FilterTests
         // Assert
         try
         {
-            var h5File = H5File.OpenRead(filePath);
+            using var h5File = H5File.OpenRead(filePath);
             var dataset = h5File.Dataset("filtered");
             var actual = dataset.Read<int[]>();
 
@@ -343,7 +344,7 @@ public class FilterTests
         // Assert
         try
         {
-            var h5File = H5File.OpenRead(filePath);
+            using var h5File = H5File.OpenRead(filePath);
             var dataset = h5File.Dataset("filtered");
             var actual = dataset.Read<int[]>();
 
@@ -428,7 +429,7 @@ public class FilterTests
         // Assert
         try
         {
-            var h5File = H5File.OpenRead(filePath);
+            using var h5File = H5File.OpenRead(filePath);
             var dataset = h5File.Dataset("filtered");
             var actual = dataset.Read<int[]>();
 

--- a/tests/PureHDF.Tests/PureHDF.Tests.csproj
+++ b/tests/PureHDF.Tests/PureHDF.Tests.csproj
@@ -16,8 +16,9 @@
   <ItemGroup>
     <PackageReference Include="HDF.PInvoke.1.10" Version="1.10.612" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/PureHDF.Tests/Reading/AttributeTests@misc.cs
+++ b/tests/PureHDF.Tests/Reading/AttributeTests@misc.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace PureHDF.Tests.Reading;
 
+[Collection(SharedHdf5StateCollection.Name)]
 public partial class AttributeTests
 {
     [Fact]

--- a/tests/PureHDF.Tests/Reading/ConcurrencyTests.cs
+++ b/tests/PureHDF.Tests/Reading/ConcurrencyTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace PureHDF.Tests.Reading;
 
+[Collection(SharedHdf5StateCollection.Name)]
 public class ConcurrencyTests
 {
     [Fact]

--- a/tests/PureHDF.Tests/Reading/DatasetTests@misc.cs
+++ b/tests/PureHDF.Tests/Reading/DatasetTests@misc.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace PureHDF.Tests.Reading;
 
+[Collection(SharedHdf5StateCollection.Name)]
 public partial class DatasetTests
 {
     [Fact]

--- a/tests/PureHDF.Tests/Reading/FilePathUtilsTests.cs
+++ b/tests/PureHDF.Tests/Reading/FilePathUtilsTests.cs
@@ -30,8 +30,8 @@ public class FilePathUtilsTests
     {
         // Arrange
         var relativePath = "path/file.h5";
-        var envPrefix = "/env/variable:/env/variable2";
-        var expected = Path.Combine(envPrefix.Split(':')[1], relativePath);
+        var envPrefix = $"/env/variable{Path.PathSeparator}/env/variable2";
+        var expected = Path.Combine(envPrefix.Split(Path.PathSeparator)[1], relativePath);
 
         bool fileExists(string filePath) => filePath == expected;
 
@@ -114,7 +114,7 @@ public class FilePathUtilsTests
     {
         // Arrange
         var expected = "path/file.h5";
-        var envPrefix = "/env/variable:/env/variable2";
+        var envPrefix = $"/env/variable{Path.PathSeparator}/env/variable2";
         var linkAccessPrefix = "/link/access";
 
         var linkAccess = new H5LinkAccess(ExternalLinkPrefix: linkAccessPrefix);
@@ -144,7 +144,7 @@ public class FilePathUtilsTests
     {
         // Arrange
         var filePath = "path/file.h5";
-        var envPrefix = "/env/variable:/env/variable2";
+        var envPrefix = $"/env/variable{Path.PathSeparator}/env/variable2";
         var linkAccessPrefix = "/link/access";
 
         var linkAccess = new H5LinkAccess(ExternalLinkPrefix: linkAccessPrefix);
@@ -193,8 +193,8 @@ public class FilePathUtilsTests
     {
         // Arrange
         var relativePath = "path/file.h5";
-        var envPrefix = "/env/variable:/env/variable2";
-        var expected = Path.Combine(envPrefix.Split(':')[1], relativePath);
+        var envPrefix = $"/env/variable{Path.PathSeparator}/env/variable2";
+        var expected = Path.Combine(envPrefix.Split(Path.PathSeparator)[1], relativePath);
 
         bool fileExists(string filePath) => filePath == expected;
 
@@ -277,7 +277,7 @@ public class FilePathUtilsTests
     {
         // Arrange
         var expected = "path/file.h5";
-        var envPrefix = "/env/variable:/env/variable2";
+        var envPrefix = $"/env/variable{Path.PathSeparator}/env/variable2";
         var datasetAccessPrefix = "/dataset/access";
 
         var datasetAccess = new H5DatasetAccess(ExternalFilePrefix: datasetAccessPrefix);
@@ -307,7 +307,7 @@ public class FilePathUtilsTests
     {
         // Arrange
         var filePath = "path/file.h5";
-        var envPrefix = "/env/variable:/env/variable2";
+        var envPrefix = $"/env/variable{Path.PathSeparator}/env/variable2";
         var datasetAccessPrefix = "/dataset/access";
 
         var datasetAccess = new H5DatasetAccess(ExternalFilePrefix: datasetAccessPrefix);

--- a/tests/PureHDF.Tests/Reading/LinkTests.cs
+++ b/tests/PureHDF.Tests/Reading/LinkTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace PureHDF.Tests.Reading;
 
+[Collection(SharedHdf5StateCollection.Name)]
 public class LinkTests
 {
     [Theory]

--- a/tests/PureHDF.Tests/Reading/PureHDF.VOL/HsdsTests.cs
+++ b/tests/PureHDF.Tests/Reading/PureHDF.VOL/HsdsTests.cs
@@ -6,16 +6,23 @@ namespace PureHDF.Tests.Reading.VOL;
 
 public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixture>
 {
-    private readonly IHsdsConnector _connector = fixture.Connector;
+    private readonly HsdsTestsFixture _fixture = fixture;
 
-    [Fact]
+    private IHsdsConnector RequireConnector()
+    {
+        Skip.IfNot(_fixture.Connector is not null, _fixture.SkipReason);
+        return _fixture.Connector!;
+    }
+
+    [SkippableFact]
     public void CanGetGroup()
     {
         // Arrange
+        var connector = RequireConnector();
         var expected = "g1.1";
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Group($"/g1/{expected}")
             .Name;
 
@@ -23,13 +30,14 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
         Assert.Equal(expected, actual);
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanGetChildren()
     {
         // Arrange
+        var connector = RequireConnector();
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Children();
 
         // Assert
@@ -38,27 +46,29 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
             child => Assert.Equal("g2", child.Name));
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanGetAttribute()
     {
         // Arrange
+        var connector = RequireConnector();
         var expected = "attr1";
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Attribute(expected);
 
         // Assert
         Assert.Equal(expected, actual.Name);
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanGetAttributes()
     {
         // Arrange
+        var connector = RequireConnector();
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Attributes();
 
         // Assert
@@ -67,14 +77,15 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
             attribute => Assert.Equal("attr2", attribute.Name));
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanReadAttribute()
     {
         // Arrange
+        var connector = RequireConnector();
         var expected = new int[] { 97, 98, 99, 100, 101, 102, 103, 104, 105, 0 };
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Attribute("attr1")
             .Read<int[]>();
 
@@ -82,24 +93,26 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
         Assert.True(expected.SequenceEqual(actual));
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanGetDataset()
     {
         // Arrange
+        var connector = RequireConnector();
         var expected = "dset1.1.1";
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Dataset($"/g1/g1.1/{expected}");
 
         // Assert
         Assert.Equal(expected, actual.Name);
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanReadDataset()
     {
         // Arrange
+        var connector = RequireConnector();
         var expected = new int[100];
 
         for (int i = 0; i < 10; i++)
@@ -113,7 +126,7 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
         // TODO: handle memory selections
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Dataset("/g1/g1.1/dset1.1.1")
             .Read<int[]>();
 
@@ -121,10 +134,11 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
         Assert.True(expected.SequenceEqual(actual));
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanReadDatasetWithFileSelection_Hyperslab()
     {
         // Arrange
+        var connector = RequireConnector();
         var expected = new int[] { 6, 10, 14, 15, 25, 35 };
 
         var fileSelection = new HyperslabSelection(
@@ -136,7 +150,7 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
         );
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Dataset("/g1/g1.1/dset1.1.1")
             .Read<int[]>(fileSelection);
 
@@ -144,10 +158,11 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
         Assert.True(expected.SequenceEqual(actual));
     }
 
-    [Fact]
+    [SkippableFact]
     public void CanReadDatasetWithFileSelection_Point()
     {
         // Arrange
+        var connector = RequireConnector();
         var expected = new int[] { 0, 2, 6, 12 };
 
         var fileSelection = new PointSelection(new ulong[,] {
@@ -158,7 +173,7 @@ public class HsdsTests(HsdsTestsFixture fixture) : IClassFixture<HsdsTestsFixtur
         });
 
         // Act
-        var actual = _connector
+        var actual = connector
             .Dataset("/g1/g1.1/dset1.1.1")
             .Read<int[]>(fileSelection);
 

--- a/tests/PureHDF.Tests/Reading/PureHDF.VOL/HsdsTestsFixture.cs
+++ b/tests/PureHDF.Tests/Reading/PureHDF.VOL/HsdsTestsFixture.cs
@@ -11,7 +11,7 @@ public class HsdsTestsFixture
     {
         var domainName = "/shared/tall.h5";
 
-        var authenticationString = $"admin:admin";
+        var authenticationString = "admin:admin";
         var base64String = Convert.ToBase64String(Encoding.ASCII.GetBytes(authenticationString));
 
         var httpClient = new HttpClient()
@@ -22,9 +22,22 @@ public class HsdsTestsFixture
         httpClient.DefaultRequestHeaders.Authorization
             = new AuthenticationHeaderValue("Basic", base64String);
 
-        var client = new HsdsClient(httpClient);
-        Connector = HsdsConnector.Create(domainName, client);
+        try
+        {
+            var client = new HsdsClient(httpClient);
+            Connector = HsdsConnector.Create(domainName, client);
+        }
+        catch (Exception ex)
+        {
+            // No HSDS server reachable — leave Connector null and record the
+            // reason. Individual tests will Skip.IfNot on Connector and surface
+            // SkipReason in the runner output instead of failing.
+            SkipReason = $"HSDS server unreachable at {httpClient.BaseAddress} " +
+                         $"({ex.GetType().Name}: {ex.Message})";
+        }
     }
 
-    public IHsdsConnector Connector { get; }
+    public IHsdsConnector? Connector { get; }
+
+    public string? SkipReason { get; }
 }

--- a/tests/PureHDF.Tests/SharedHdf5StateCollection.cs
+++ b/tests/PureHDF.Tests/SharedHdf5StateCollection.cs
@@ -1,0 +1,27 @@
+using Xunit;
+
+namespace PureHDF.Tests;
+
+// Test classes that read HDF5 files (via PureHDF and/or the native HDF5 C
+// library through HDF.PInvoke) touch a fair amount of process-global state:
+//
+//   * PureHDF's static NativeCache (file map + global-heap map keyed by driver)
+//     and H5Filter.Registrations (notably mutated by H5Filter.ResetRegistrations()
+//     in several filter tests).
+//   * The native HDF5 C library's own global file-tracking state, exercised by
+//     TestUtils.PrepareTestFile(...) when it shells out to H5F.create / H5F.close.
+//
+// xUnit's default behaviour runs each test class in its own implicit collection,
+// and runs collections in parallel. When two of these classes happen to land on
+// different threads at the same time, the global state above is racy enough that
+// individual reads occasionally fail with errors like "process cannot access the
+// file" on Windows, or stale filter registrations during a read.
+//
+// Test classes opted in to this collection serialise with each other and with
+// any other test class also opted in. Classes outside the collection (e.g. the
+// pure write-side tests) continue to run in parallel as before.
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class SharedHdf5StateCollection
+{
+    public const string Name = "PureHDF shared static state";
+}

--- a/tests/PureHDF.Tests/TestUtils/TestUtils.cs
+++ b/tests/PureHDF.Tests/TestUtils/TestUtils.cs
@@ -11,9 +11,10 @@ public partial class TestUtils
 {
     public static string? DumpH5File(string filePath)
     {
-        var dump = default(string);
-
-        var h5dumpProcess = new Process
+        // Read stdout and stderr concurrently on background tasks to
+        // avoid deadlock if h5dump writes more than ~64 KB to stderr before
+        // exiting.
+        using var h5dumpProcess = new Process
         {
             StartInfo = new ProcessStartInfo
             {
@@ -28,26 +29,42 @@ public partial class TestUtils
 
         h5dumpProcess.Start();
 
-        while (!h5dumpProcess.StandardOutput.EndOfStream)
+        var stdoutTask = Task.Run(() => h5dumpProcess.StandardOutput.ReadToEnd());
+        var stderrTask = Task.Run(() => h5dumpProcess.StandardError.ReadToEnd());
+
+        // Cap wall time so a hung h5dump surfaces as a clear test failure rather than the
+        // whole test run hanging indefinitely.
+        const int timeoutMs = 30_000;
+
+        if (!h5dumpProcess.WaitForExit(timeoutMs))
         {
-            var line = h5dumpProcess.StandardOutput.ReadLine();
+            try { h5dumpProcess.Kill(entireProcessTree: true); }
+            catch { }
 
-            if (dump is null)
-                dump = line;
-
-            else
-                dump += Environment.NewLine + line;
+            throw new TimeoutException(
+                $"h5dump did not exit within {timeoutMs} ms for '{filePath}'.");
         }
 
-        while (!h5dumpProcess.StandardError.EndOfStream)
+        var stdoutStr = stdoutTask.GetAwaiter().GetResult().TrimEnd('\r', '\n');
+        var stderrStr = stderrTask.GetAwaiter().GetResult().TrimEnd('\r', '\n');
+        if (stdoutStr.Length == 0)
         {
-            var line = h5dumpProcess.StandardError.ReadLine();
+            throw new InvalidOperationException(
+                $"h5dump produced no stdout for '{filePath}' (exit code {h5dumpProcess.ExitCode}). " +
+                $"stderr:{Environment.NewLine}{stderrStr}");
+        }
 
-            if (dump is null)
-                dump = line;
-
-            else
-                dump += Environment.NewLine + line;
+        var dump = stderrStr.Length > 0
+            ? stdoutStr + Environment.NewLine + stderrStr
+            : stdoutStr;
+			
+        // Strip h5dump's trailing HDF5-DIAG error stack so the comparison
+        // doesn't depend on the locally-installed h5dump version. 
+        if (dump is not null)
+        {
+            var diagIdx = dump.IndexOf("HDF5-DIAG:", StringComparison.Ordinal);
+            if (diagIdx >= 0)
+                dump = dump[..diagIdx].TrimEnd('\r', '\n');
         }
 
         return dump;

--- a/tests/PureHDF.Tests/TestUtils/TestUtils@filter.cs
+++ b/tests/PureHDF.Tests/TestUtils/TestUtils@filter.cs
@@ -17,12 +17,28 @@ public partial class TestUtils
             2 => H5T.NATIVE_UINT16,
             4 => H5T.NATIVE_UINT32,
             8 => H5T.NATIVE_UINT64,
-            16 => H5T.NATIVE_LDOUBLE,
+            16 => CreateOpaque16(), // H5T.NATIVE_LDOUBLE is 16 bytes on posix, 8 bytes on windows
             _ => throw new Exception($"The value '{bytesOfType}' of the 'bytesOfType' parameter is not within the valid range.")
         };
 
-        Add(ContainerType.Dataset, fileId, "filtered", $"shuffle_{bytesOfType}", typeId, dataset, (ulong)length, cpl: dcpl_id);
-        _ = H5P.close(dcpl_id);
+        try
+        {
+	        Add(ContainerType.Dataset, fileId, "filtered", $"shuffle_{bytesOfType}", typeId, dataset, (ulong)length, cpl: dcpl_id);
+        }
+        finally
+        {
+            _ = H5P.close(dcpl_id);
+
+            if (bytesOfType == 16)
+                _ = H5T.close(typeId);
+        }
+
+        static long CreateOpaque16()
+        {
+            var id = H5T.create(H5T.class_t.OPAQUE, new IntPtr(16));
+            H5T.set_tag(id, "16-byte opaque");
+            return id;
+        }
     }
 
     public static unsafe void AddFilteredDataset_ZLib(long fileId)


### PR DESCRIPTION
This PR makes the tests work on Windows, and compatible with .net 10 sdk and a newer h5dump.

It fixes some problems with test parallelism and inability to delete files due to un-garbage-collected handles.

- Add SharedHdf5StateCollection to serialize tests using HDF5/global state, preventing failures from sharing problems.
- Update xUnit dependencies and add Xunit.SkippableFact for conditional test skipping.
- Fix FilePathUtils handling of Widnows environment variables.
- Make TestUtils.DumpH5File work with newer h5dump.
- Use 'using' for H5File in tests to prevent attempts to delete in-use files.
- Add .AsSpan() to fix build problem in .net 10 sdk.
- Handle 16-byte types in filter tests with opaque type for portability (because LDOUBLE is 8 bytes in Windows).
- Make HSDS Skip (not fail) if server is unreachable.
- Fix a chunked storage encoding problem reported by h5dump  2.1.
- Dispose VirtualDatasetStream in H5D_Virtual (tests failed when the files couldn't be replaced).