### PR TITLE
Batch variable-length cell header reads

### DIFF
--- a/benchmarks/PureHDF.Benchmarks/VariableLengthCompoundRead.cs
+++ b/benchmarks/PureHDF.Benchmarks/VariableLengthCompoundRead.cs
@@ -1,0 +1,124 @@
+using BenchmarkDotNet.Attributes;
+using PureHDF;
+using PureHDF.Selections;
+using PureHDF.VOL.Native;
+using System.Runtime.InteropServices;
+
+namespace Benchmark;
+
+// Exercises Read<T[][]> on a 1-D dataset of variable-length sequences of a
+// small blittable struct, under three access patterns:
+//
+//   - ReadAll       : 1 Read call for the whole dataset
+//   - ReadByWindow  : 10 Read calls of 60 cells each
+//   - ReadPerCell   : 600 Read calls of 1 cell each
+//
+// Each access pattern measures the same total decode work but a different
+// per-Read-call multiplier, so the relative cost of per-Read fixed overhead
+// versus per-cell decode work shows up across the three rows.
+[MemoryDiagnoser]
+public class VariableLengthCompoundRead
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct Sample
+    {
+        public double X;
+        public float Y;
+    }
+
+    private const int CellCount = 600;
+    private const int ElementsPerCell = 200;
+    private const int WindowSize = 60;
+
+    private string _filePath = default!;
+    private NativeFile _file = default!;
+    private IH5Dataset _dataset = default!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _filePath = Path.Combine(Path.GetTempPath(), $"purehdf-vl-bench-{Guid.NewGuid():N}.h5");
+
+        var random = new Random(42);
+        var data = new Sample[CellCount][];
+        for (int i = 0; i < CellCount; i++)
+        {
+            var arr = new Sample[ElementsPerCell];
+            for (int j = 0; j < ElementsPerCell; j++)
+                arr[j] = new Sample { X = random.NextDouble(), Y = (float)random.NextDouble() };
+            data[i] = arr;
+        }
+
+        var writeFile = new H5File();
+        var declared = new H5Dataset<Sample[][]>([(ulong)CellCount]);
+        writeFile["dataset"] = declared;
+
+        using (var writer = writeFile.BeginWrite(_filePath))
+            writer.Write(declared, data);
+
+        _file = H5File.OpenRead(_filePath);
+        _dataset = _file.Dataset("dataset");
+
+        var probe = _dataset.Read<Sample[][]>()!;
+        if (probe.Length != CellCount)
+            throw new Exception($"setup produced {probe.Length} cells, expected {CellCount}");
+
+        for (int i = 0; i < CellCount; i++)
+        {
+            if (probe[i] is null || probe[i]!.Length != ElementsPerCell)
+                throw new Exception(
+                    $"cell {i} has length {probe[i]?.Length ?? -1}, expected {ElementsPerCell}");
+        }
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _file?.Dispose();
+        if (File.Exists(_filePath))
+        {
+            try { File.Delete(_filePath); } catch { /* ignore */ }
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public int ReadAll()
+    {
+        var result = _dataset.Read<Sample[][]>()!;
+        var total = 0;
+        for (int i = 0; i < result.Length; i++)
+            total += result[i]?.Length ?? 0;
+        return total;
+    }
+
+    [Benchmark]
+    public int ReadByWindow()
+    {
+        var total = 0;
+        for (int start = 0; start + WindowSize <= CellCount; start += WindowSize)
+        {
+            var sel = new HyperslabSelection(start: (ulong)start, block: (ulong)WindowSize);
+            var window = _dataset.Read<Sample[][]>(
+                fileSelection: sel,
+                memoryDims: [(ulong)WindowSize])!;
+            for (int i = 0; i < window.Length; i++)
+                total += window[i]?.Length ?? 0;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int ReadPerCell()
+    {
+        var total = 0;
+        for (int i = 0; i < CellCount; i++)
+        {
+            var sel = new HyperslabSelection(start: (ulong)i, block: 1);
+            var cell = _dataset.Read<Sample[][]>(
+                fileSelection: sel,
+                memoryDims: [1UL])!;
+            total += cell[0]?.Length ?? 0;
+        }
+        return total;
+    }
+}

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
@@ -998,15 +998,10 @@ internal partial record class DatatypeMessage(
         // feeding the per-cell decoder from an in-memory wrapper collapses the
         // per-call dispatch + position-tracking overhead. The per-cell element
         // decoder itself is unchanged.
-        var isVariableLengthHeaderBatchable =
-            Class == DatatypeMessageClass.VariableLength &&
-            BitField is VariableLengthBitFieldDescription vlBitField &&
-            (vlBitField.Type == InternalVariableLengthType.Sequence ||
-                vlBitField.Type == InternalVariableLengthType.String);
 
-        if (isVariableLengthHeaderBatchable)
+        if (Class == DatatypeMessageClass.VariableLength)
         {
-            var cellHeaderSize = sizeof(uint) + (int)context.Superblock.OffsetsSize + sizeof(uint);
+            var cellHeaderSize = sizeof(uint) + context.Superblock.OffsetsSize + sizeof(uint);
 
             void decodeBatched(IH5ReadStream source, Span<T> target)
             {
@@ -1014,41 +1009,38 @@ internal partial record class DatatypeMessage(
                     return;
 
                 var totalBytes = target.Length * cellHeaderSize;
-                var rented = ArrayPool<byte>.Shared.Rent(totalBytes);
 
-                try
+                using var memoryOwner = MemoryPool<byte>.Shared.Rent(totalBytes);
+                var bulk = memoryOwner.Memory[..totalBytes];
+
+                source.ReadDataset(bulk.Span);
+
+                var localSource = new SystemMemoryStream(bulk);
+                var targetSpan = target;
+
+                for (int i = 0; i < target.Length; i++)
                 {
-                    var bulk = rented.AsMemory(0, totalBytes);
-                    source.ReadDataset(bulk.Span);
-
-                    var localSource = new SystemMemoryStream(bulk);
-                    var targetSpan = target;
-
-                    for (int i = 0; i < target.Length; i++)
-                    {
-                        targetSpan[i] = (T)elementDecode(localSource)!;
-                    }
-                }
-                finally
-                {
-                    ArrayPool<byte>.Shared.Return(rented);
+                    targetSpan[i] = (T)elementDecode(localSource)!;
                 }
             }
 
             return decodeBatched;
         }
 
-        void decode(IH5ReadStream source, Span<T> target)
+        else
         {
-            var targetSpan = target;
-
-            for (int i = 0; i < target.Length; i++)
+            void decode(IH5ReadStream source, Span<T> target)
             {
-                targetSpan[i] = (T)elementDecode(source)!;
-            }
-        };
+                var targetSpan = target;
 
-        return decode;
+                for (int i = 0; i < target.Length; i++)
+                {
+                    targetSpan[i] = (T)elementDecode(source)!;
+                }
+            };
+
+            return decode;
+        }
     }
 
     private static DecodeDelegate<T> GetDecodeInfoForUnmanagedMemory<T>()

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
@@ -989,6 +989,55 @@ internal partial record class DatatypeMessage(
     {
         var elementDecode = GetDecodeInfoForScalar(context, typeof(T)).Decode;
 
+        // Variable-length sequences and strings store a fixed-size (length + global
+        // heap id) header per cell in the dataset stream, with the payload living
+        // in the global heap. The per-cell element decoder reads that header via
+        // source.ReadDataset(headerBytes) before resolving the heap object — and on
+        // an N-cell decode pass that becomes N small ReadDataset calls into the
+        // underlying IH5ReadStream. Pre-reading all N headers in one bulk call and
+        // feeding the per-cell decoder from an in-memory wrapper collapses the
+        // per-call dispatch + position-tracking overhead. The per-cell element
+        // decoder itself is unchanged.
+        var isVariableLengthHeaderBatchable =
+            Class == DatatypeMessageClass.VariableLength &&
+            BitField is VariableLengthBitFieldDescription vlBitField &&
+            (vlBitField.Type == InternalVariableLengthType.Sequence ||
+                vlBitField.Type == InternalVariableLengthType.String);
+
+        if (isVariableLengthHeaderBatchable)
+        {
+            var cellHeaderSize = sizeof(uint) + (int)context.Superblock.OffsetsSize + sizeof(uint);
+
+            void decodeBatched(IH5ReadStream source, Span<T> target)
+            {
+                if (target.Length == 0)
+                    return;
+
+                var totalBytes = target.Length * cellHeaderSize;
+                var rented = ArrayPool<byte>.Shared.Rent(totalBytes);
+
+                try
+                {
+                    var bulk = rented.AsMemory(0, totalBytes);
+                    source.ReadDataset(bulk.Span);
+
+                    var localSource = new SystemMemoryStream(bulk);
+                    var targetSpan = target;
+
+                    for (int i = 0; i < target.Length; i++)
+                    {
+                        targetSpan[i] = (T)elementDecode(localSource)!;
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
+            }
+
+            return decodeBatched;
+        }
+
         void decode(IH5ReadStream source, Span<T> target)
         {
             var targetSpan = target;


### PR DESCRIPTION
(Updated to remove references to a JIT problem that was my flaky CPU)

## Summary

For variable-length sequences and strings, every cell in a `Read<T>` decode pass reads its own header from the dataset stream before resolving the heap object and decoding the payload. 
On an N-cell read that's N `IH5ReadStream.ReadDataset` calls, each with their own overhead.

This PR adds a batched code path in `DatatypeMessage.GetDecodeInfoForReferenceMemory<T>` which is selected if it detects the variable-length sequence/string case at decoder-construction time. When active, it bulk-reads `target.Length * cellHeaderSize` bytes from the source in **one** `ReadDataset` call, wraps the result in a `SystemMemoryStream`, and feeds the per-cell `ElementDecodeDelegate` from that in-memory wrapper (the buffer is rented from `ArrayPool<byte>.Shared`). The per-cell decoder itself is unchanged - it still reads its header through `IH5ReadStream`, but that's now from memory with no per-call overhead.

This should improve the performance of reading multiple cells at a time, but not penalise the single-cell read, or reads of non-blittable types.

Other decoders (fixed-length string, unmanaged element, reference compound, …) are unaffected.

## Performance

**The performance improvement in this PR builds on top of other PRs. Without those, the improvement is modest.**

_I used AI to turn the multiple benchmark results folders from my tests into this synopsis:_

Benchmark: `benchmarks/PureHDF.Benchmarks/VariableLengthCompoundRead.cs` — 1-D dataset of 600 variable-length sequences, each holding 200 elements of a 12-byte blittable struct. Three access patterns:

- **ReadAll** — one `Read<Sample[][]>` for the whole dataset (1× per-Read dispatch, 600 cells)
- **ReadByWindow** — 10 reads of 60 cells each
- **ReadPerCell** — 600 reads of 1 cell each (1 cell per read, so batching has nothing to batch)

Hardware: i9-13900KS, Windows 11, .NET 8.0.27, BenchmarkDotNet default job. 

### 1. On master (no other PRs applied)

  | Method        | Before    | After     | Δ wall | Δ alloc |
  |---------------|----------:|----------:|-------:|--------:|
  | ReadAll       | 5.836 ms  | 4.843 ms  | **−17%** | 0% |
  | ReadByWindow  | 5.670 ms  | 4.812 ms  | **−15%** | 0% |
  | ReadPerCell   | 6.747 ms  | 6.739 ms  | 0%       | 0% |

The win is modest because the per-cell decoder on master is dominated by per-element `MethodInfo.Invoke` plus per-cell `Array.CreateInstance` and per-element boxing — batching only collapses the per-cell stream-dispatch overhead, which is a small fraction of total time.

### 2. On top of #161 (reflection caching)

| Method        | Before   | After    | Δ wall | Δ alloc |
|---------------|---------:|---------:|-------:|--------:|
| ReadAll       |  4.302 ms | 3.351 ms | **−22%** | 0% |
| ReadByWindow  | 4.233 ms | 3.304 ms | **−22%** | 0% |
| ReadPerCell   | 4.689 ms | 4.685 ms |   0%   | 0% |

Slightly larger relative gain than master alone — #161 makes the dispatch part of each `Read` call cheaper, so the share of total time owed to per-cell stream dispatch grows.

### 3. On top of #162 (blittable VL fast path)

| Method        | Before    | After     | Δ wall | Δ alloc |
|---------------|----------:|----------:|-------:|--------:|
| ReadAll       | 940.0 µs |   108.1 µs | **−88%** | 0% |
| ReadByWindow  |  919.9 µs |   136.4 µs | **−85%** | 0% |
| ReadPerCell   |  2 201.9 µs | 2 342.5 µs |  +6%   | +1% |

This is where the change earns its keep. #162 makes the per-cell decode itself essentially free (one `MemoryMarshal.Cast` + `CopyTo`), so on the bulk paths the per-cell stream dispatch was the dominant remaining cost — collapsing 600 small reads into 1 takes wall-time down by ~85–88%. `ReadPerCell` (1 cell per read, nothing to batch) is unchanged within noise.

### 4. On top of both #161 + #162

| Method        | Before    | After     | Δ wall | Δ alloc |
|---------------|----------:|----------:|-------:|--------:|
| ReadAll       | 920.6 µs |   103.3 µs | **−89%** | 0% |
| ReadByWindow  | 902.9 µs |   115.5 µs | **−87%** | 0% |
| ReadPerCell   | 1 386.6 µs | 1 391.4 µs |   0%   | +1% |

Bulk-path numbers are essentially the same as scenario 3 — #161's contribution on this benchmark is concentrated in `ReadPerCell` (where it cuts per-`Read` reflection-dispatch cost), not in the per-cell decoder. On `ReadAll` / `ReadByWindow` the dominant remaining cost after #162 is per-cell stream dispatch, which is what this PR removes.

