### PR TITLE
feat(writing): hard links for shared objects and raw values

### DIFF
--- a/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
@@ -50,6 +50,7 @@ partial class H5NativeWriter
             TypeToMessageMap: new(),
             ObjectToAddressMap: new(),
             ObjectReferenceCountMap: new(),
+            RawValueToDatasetMap: new(ReferenceEqualityComparer.Instance),
             ShortlivedStream: new(memory: default)
         );
 
@@ -70,7 +71,7 @@ partial class H5NativeWriter
         _rootGroupAddress = EncodeGroup(File);
     }
 
-    private static void CountReferences(H5Group root, Dictionary<H5Object, int> counts)
+    private void CountReferences(H5Group root, Dictionary<H5Object, int> counts)
     {
         var visitedGroups = new HashSet<H5Group>();
 
@@ -78,20 +79,39 @@ partial class H5NativeWriter
         {
             foreach (var entry in group)
             {
-                // Only actual H5Object instances can be shared; raw values are wrapped
-                // into a fresh H5Dataset per occurrence and are therefore never linked.
-                if (entry.Value is H5Object h5Object)
-                {
-                    counts.TryGetValue(h5Object, out var current);
-                    counts[h5Object] = current + 1;
+                // Soft links do not contribute to the target's hard-link count.
+                if (entry.Value is H5SoftLink)
+                    continue;
 
-                    if (entry.Value is H5Group childGroup && visitedGroups.Add(childGroup))
-                        Walk(childGroup);
-                }
+                // Resolve to the (possibly cached) H5Object so that both actual H5Object
+                // instances and shared raw values are counted by object identity.
+                var h5Object = GetH5Object(entry.Value);
+
+                counts.TryGetValue(h5Object, out var current);
+                counts[h5Object] = current + 1;
+
+                if (entry.Value is H5Group childGroup && visitedGroups.Add(childGroup))
+                    Walk(childGroup);
             }
         }
 
         Walk(root);
+    }
+
+    private H5Object GetH5Object(object value)
+    {
+        if (value is H5Object h5Object)
+            return h5Object;
+
+        // Wrap raw values into a single H5Dataset per instance so that a value assigned
+        // to multiple locations is deduplicated and hard-linked just like an H5Object.
+        if (!Context.RawValueToDatasetMap.TryGetValue(value, out var dataset))
+        {
+            dataset = new H5Dataset(value);
+            Context.RawValueToDatasetMap[value] = dataset;
+        }
+
+        return dataset;
     }
 
     private void AppendReferenceCountToHeaderMessages(H5Object h5Object, List<HeaderMessage> headerMessages)
@@ -149,7 +169,7 @@ partial class H5NativeWriter
 
             else
             {
-                var h5Object = entry.Value as H5Object ?? new H5Dataset(entry.Value);
+                var h5Object = GetH5Object(entry.Value);
 
                 if (!Context.ObjectToAddressMap.TryGetValue(h5Object, out linkAddress))
                 {

--- a/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
@@ -49,6 +49,7 @@ partial class H5NativeWriter
             DatasetInfoToObjectHeaderMap: new(),
             TypeToMessageMap: new(),
             ObjectToAddressMap: new(),
+            ObjectReferenceCountMap: new(),
             ShortlivedStream: new(memory: default)
         );
 
@@ -60,9 +61,54 @@ partial class H5NativeWriter
 
     internal void Write()
     {
+        // Count the incoming links for every shared object so that multiply-linked
+        // objects can carry an accurate object reference count message (hard links).
+        CountReferences(File, Context.ObjectReferenceCountMap);
+
         // root group
         Context.Driver.SeekRelativeToBaseAddress(Superblock23.ENCODE_SIZE);
         _rootGroupAddress = EncodeGroup(File);
+    }
+
+    private static void CountReferences(H5Group root, Dictionary<H5Object, int> counts)
+    {
+        var visitedGroups = new HashSet<H5Group>();
+
+        void Walk(H5Group group)
+        {
+            foreach (var entry in group)
+            {
+                // Only actual H5Object instances can be shared; raw values are wrapped
+                // into a fresh H5Dataset per occurrence and are therefore never linked.
+                if (entry.Value is H5Object h5Object)
+                {
+                    counts.TryGetValue(h5Object, out var current);
+                    counts[h5Object] = current + 1;
+
+                    if (entry.Value is H5Group childGroup && visitedGroups.Add(childGroup))
+                        Walk(childGroup);
+                }
+            }
+        }
+
+        Walk(root);
+    }
+
+    private void AppendReferenceCountToHeaderMessages(H5Object h5Object, List<HeaderMessage> headerMessages)
+    {
+        // The object reference count message is only required for multiply-linked
+        // objects; a missing message is interpreted as a reference count of 1.
+        if (Context.ObjectReferenceCountMap.TryGetValue(h5Object, out var count) && count > 1)
+        {
+            var objectReferenceCountMessage = new ObjectReferenceCountMessage(
+                ReferenceCount: (uint)count
+            )
+            {
+                Version = 0
+            };
+
+            headerMessages.Add(ToHeaderMessage(objectReferenceCountMessage));
+        }
     }
 
     internal ulong EncodeGroup(
@@ -150,6 +196,8 @@ partial class H5NativeWriter
 
             headerMessages.Add(ToHeaderMessage(linkMessage));
         }
+
+        AppendReferenceCountToHeaderMessages(group, headerMessages);
 
         var objectHeader = new ObjectHeader2(
             Address: default,
@@ -294,6 +342,8 @@ partial class H5NativeWriter
 
         if (dataset.InternalAttributes is not null)
             AppendAttributesToHeaderMessages(dataset.InternalAttributes, headerMessages, Context);
+
+        AppendReferenceCountToHeaderMessages(dataset, headerMessages);
 
         // object header
         var objectHeader = new ObjectHeader2(

--- a/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
@@ -12,5 +12,6 @@ internal record NativeWriteContext(
     Dictionary<Type, (DatatypeMessage, ElementEncodeDelegate)> TypeToMessageMap,
     Dictionary<H5Object, ulong> ObjectToAddressMap,
     Dictionary<H5Object, int> ObjectReferenceCountMap,
+    Dictionary<object, H5Dataset> RawValueToDatasetMap,
     SystemMemoryStream ShortlivedStream
 );

--- a/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
@@ -11,5 +11,6 @@ internal record NativeWriteContext(
     Dictionary<DatasetInfo, (long ObjectHeaderStart, int ObjectHeaderLength)> DatasetInfoToObjectHeaderMap,
     Dictionary<Type, (DatatypeMessage, ElementEncodeDelegate)> TypeToMessageMap,
     Dictionary<H5Object, ulong> ObjectToAddressMap,
+    Dictionary<H5Object, int> ObjectReferenceCountMap,
     SystemMemoryStream ShortlivedStream
 );

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/ObjectReferenceCount/ObjectReferenceCountMessage.Writing.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/ObjectReferenceCount/ObjectReferenceCountMessage.Writing.cs
@@ -1,0 +1,18 @@
+namespace PureHDF.VOL.Native;
+
+internal partial record class ObjectReferenceCountMessage
+{
+    public override ushort GetEncodeSize()
+    {
+        return sizeof(byte) + sizeof(uint);
+    }
+
+    public override void Encode(H5DriverBase driver)
+    {
+        // version
+        driver.Write(_version);
+
+        // reference count
+        driver.Write(ReferenceCount);
+    }
+}

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/ObjectReferenceCount/ObjectReferenceCountMessage.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/ObjectReferenceCount/ObjectReferenceCountMessage.cs
@@ -1,6 +1,6 @@
 ﻿namespace PureHDF.VOL.Native;
 
-internal record class ObjectReferenceCountMessage(
+internal partial record class ObjectReferenceCountMessage(
     uint ReferenceCount
 ) : Message
 {

--- a/tests/PureHDF.Tests/DumpFiles/links_shared_dataset.dump
+++ b/tests/PureHDF.Tests/DumpFiles/links_shared_dataset.dump
@@ -1,0 +1,16 @@
+HDF5 "<file-path>" {
+GROUP "/" {
+   DATASET "dataset_a" {
+      DATATYPE  H5T_STD_I32LE
+      DATASPACE  SIMPLE { ( 3 ) / ( 3 ) }
+      DATA {
+      (0): 1, 2, 3
+      }
+   }
+   GROUP "group" {
+      DATASET "dataset_b" {
+         HARDLINK "/dataset_a"
+      }
+   }
+}
+}

--- a/tests/PureHDF.Tests/Writing/LinkTests.cs
+++ b/tests/PureHDF.Tests/Writing/LinkTests.cs
@@ -132,6 +132,73 @@ public class LinkTests
     }
 
     [Fact]
+    public void CanWrite_SharedRawValue()
+    {
+        // A raw value (not wrapped in H5Dataset) assigned to multiple locations must
+        // also be encoded once and referenced by hard links.
+
+        // Arrange
+        var shared = new int[] { 1, 2, 3 };
+
+        var file = new H5File
+        {
+            ["dataset_a"] = shared,
+
+            ["group"] = new H5Group
+            {
+                ["dataset_b"] = shared
+            }
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        // Act
+        file.Write(filePath);
+
+        // Assert
+        var actual = TestUtils.DumpH5File(filePath);
+
+        var expected = File
+            .ReadAllText("DumpFiles/links_shared_dataset.dump")
+            .Replace("<file-path>", filePath);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SharedRawValue_RoundTrips()
+    {
+        // Both hard links to a shared raw value must resolve to the same data.
+
+        // Arrange
+        var expected = new int[] { 1, 2, 3 };
+
+        var file = new H5File
+        {
+            ["dataset_a"] = expected,
+
+            ["group"] = new H5Group
+            {
+                ["dataset_b"] = expected
+            }
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        // Act
+        file.Write(filePath);
+
+        // Assert
+        using var root = H5File.OpenRead(filePath);
+
+        var actualA = root.Dataset("dataset_a").Read<int[]>();
+        var actualB = root.Group("group").Dataset("dataset_b").Read<int[]>();
+
+        Assert.Equal(expected, actualA);
+        Assert.Equal(expected, actualB);
+    }
+
+    [Fact]
     public void CanWrite_Complex()
     {
         // Arrange

--- a/tests/PureHDF.Tests/Writing/LinkTests.cs
+++ b/tests/PureHDF.Tests/Writing/LinkTests.cs
@@ -64,6 +64,74 @@ public class LinkTests
     }
 
     [Fact]
+    public void CanWrite_SharedDataset()
+    {
+        // A single H5Dataset instance attached at multiple locations must be
+        // encoded once and referenced by hard links (HDF5 hard-link semantics).
+
+        // Arrange
+        var shared = new H5Dataset(data: new int[] { 1, 2, 3 });
+
+        var file = new H5File
+        {
+            ["dataset_a"] = shared,
+
+            ["group"] = new H5Group
+            {
+                ["dataset_b"] = shared
+            }
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        // Act
+        file.Write(filePath);
+
+        // Assert
+        var actual = TestUtils.DumpH5File(filePath);
+
+        var expected = File
+            .ReadAllText("DumpFiles/links_shared_dataset.dump")
+            .Replace("<file-path>", filePath);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SharedDataset_RoundTrips()
+    {
+        // Both hard links must resolve to the same data when read back.
+
+        // Arrange
+        var expected = new int[] { 1, 2, 3 };
+        var shared = new H5Dataset(data: expected);
+
+        var file = new H5File
+        {
+            ["dataset_a"] = shared,
+
+            ["group"] = new H5Group
+            {
+                ["dataset_b"] = shared
+            }
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        // Act
+        file.Write(filePath);
+
+        // Assert
+        using var root = H5File.OpenRead(filePath);
+
+        var actualA = root.Dataset("dataset_a").Read<int[]>();
+        var actualB = root.Group("group").Dataset("dataset_b").Read<int[]>();
+
+        Assert.Equal(expected, actualA);
+        Assert.Equal(expected, actualB);
+    }
+
+    [Fact]
     public void CanWrite_Complex()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Makes multiply-linked objects proper, tool-recognized HDF5 hard links on write, and extends the same behavior to shared raw values.

Sharing a single `H5Object` instance across multiple group locations already produced one object header referenced by several hard links, but the stored **link count stayed 1** because no object reference count message was written. And raw values (assigned without wrapping in `H5Dataset`) were wrapped into a fresh dataset on every occurrence, so a value shared across locations was **duplicated** rather than linked. Consequences:

- h5dump/h5ls did **not** recognise multiply-linked *datasets* as hard links (printed the data twice).
- Files were technically malformed (link count 1 with two links → deleting one link could free a still-referenced object).
- Shared raw values wasted space with full duplicates.

## Changes

- Added `Encode`/`GetEncodeSize` write support to `ObjectReferenceCountMessage` (it was read-only before).
- A pre-encode pass counts the incoming links per shared object and emits an `ObjectReferenceCountMessage` with the accurate count when an object has more than one link (omitted for count 1, per HDF5 convention). Soft links are excluded from the count.
- Raw values are wrapped into a single `H5Dataset` per instance and cached by **reference identity**, so a value shared across locations is deduplicated and hard-linked just like a shared `H5Object`. The reference-count pass and the encoder share one resolution helper to stay consistent.

Reference-identity semantics are deliberate: only the *same* instance dedups; distinct-but-equal values (and boxed value types) stay separate.

## Verification

- `h5ls`: a shared dataset now reports `Links: 2` and `Dataset, same as /dataset_a`.
- `h5dump`: the second link renders as `HARDLINK "/dataset_a"` (h5dump only collapses datasets when the stored link count > 1, so this confirms the count).
- New tests: `CanWrite_SharedDataset` / `SharedDataset_RoundTrips` (shared `H5Dataset` instance) and `CanWrite_SharedRawValue` / `SharedRawValue_RoundTrips` (shared raw value). All `Writing.LinkTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
