### PR TITLE
fix(layout): derive chunk dimension size encoded length from dimensions

### DIFF
--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/StoragePropertyDescriptions.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/StoragePropertyDescriptions.cs
@@ -194,13 +194,49 @@ internal record class ChunkedStoragePropertyDescription4(
         };
     }
 
+    /// <summary>
+    /// The number of bytes used to encode each dimension size.
+    /// <para>
+    /// The HDF5 library recomputes this value when opening the dataset and fails with
+    /// "stored chunk dimension encoding length does not match value calculated from
+    /// chunk dimensions" if it differs, so it cannot be a fixed width. This mirrors
+    /// <c>H5D__chunk_set_sizes()</c>, which computes
+    /// <c>(H5VM_log2_gen(dim[u]) + 8) / 8</c> for every dimension - including the last,
+    /// which holds the datatype size - and takes the maximum. That is the minimum
+    /// number of bytes able to hold the largest dimension size, so any width from 1 to
+    /// 8 is possible (a dimension of 65536 needs 3, not 4).
+    /// </para>
+    /// </summary>
+    internal byte DimensionSizeEncodedLength
+    {
+        get
+        {
+            var max = 0UL;
+
+            for (int i = 0; i < Rank; i++)
+            {
+                if (DimensionSizes[i] > max)
+                    max = DimensionSizes[i];
+            }
+
+            var length = 1;
+
+            while (length < 8 && max > (1UL << (length * 8)) - 1)
+            {
+                length++;
+            }
+
+            return (byte)length;
+        }
+    }
+
     public override ushort GetEncodeSize()
     {
         var encodeSize =
             sizeof(byte) +
             sizeof(byte) +
             sizeof(byte) +
-            sizeof(ulong) * Rank +
+            DimensionSizeEncodedLength * Rank +
             sizeof(byte) +
             IndexingInformation.GetEncodeSize(Flags) +
             sizeof(ulong);
@@ -219,12 +255,13 @@ internal record class ChunkedStoragePropertyDescription4(
         driver.Write(Rank);
 
         // dimension size encoded length
-        driver.Write((byte)8);
+        var dimensionSizeEncodedLength = DimensionSizeEncodedLength;
+        driver.Write(dimensionSizeEncodedLength);
 
         // dimension sizes
         for (int i = 0; i < Rank; i++)
         {
-            driver.Write(DimensionSizes[i]);
+            WriteUtils.WriteUlongArbitrary(driver, DimensionSizes[i], dimensionSizeEncodedLength);
         }
 
         // chunk indexing type

--- a/tests/PureHDF.Tests/Writing/DatasetTests@layout_chunked.cs
+++ b/tests/PureHDF.Tests/Writing/DatasetTests@layout_chunked.cs
@@ -60,6 +60,52 @@ public partial class DatasetTests
         }
     }
 
+    // https://github.com/Apollo3zehn/PureHDF/issues/164
+    [Theory]
+    [InlineData(10U, (byte)1)]        // max(10, 8)          -> 1 byte
+    [InlineData(300U, (byte)2)]       // max(300, 8)         -> 2 bytes
+    [InlineData(70000U, (byte)3)]     // max(70000, 8)       -> 3 bytes, not 4
+    [InlineData(20000000U, (byte)4)]  // max(20000000, 8)    -> 4 bytes
+    public void CanWrite_Chunked_StoresMinimalDimensionSizeEncodedLength(uint chunkSize, byte expectedEncodedLength)
+    {
+        // Arrange
+        var data = new double[chunkSize * 2];
+
+        var file = new H5File
+        {
+            ["chunked"] = new H5Dataset(data, chunks: [chunkSize])
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        // Act
+        file.Write(filePath);
+
+        // Assert
+        try
+        {
+            // HDF5 recomputes the encoding length from the chunk dimensions and rejects
+            // the layout when it differs, so it must be the minimum width that holds the
+            // largest dimension - see H5D__chunk_set_sizes(). A fixed width, or one
+            // rounded up to a power of two, makes the dataset unopenable by HDF5 2.x.
+            using var h5File = H5File.OpenRead(filePath);
+            var nativeDataset = (NativeDataset)h5File.Dataset("chunked");
+            var layout = (DataLayoutMessage4)nativeDataset.InternalDataLayout;
+            var properties = (ChunkedStoragePropertyDescription4)layout.Properties;
+
+            Assert.Equal(expectedEncodedLength, properties.DimensionSizeEncodedLength);
+
+            // and the dimension sizes must survive the narrower encoding
+            Assert.Equal(chunkSize, (uint)properties.DimensionSizes[0]);
+            Assert.Equal(sizeof(double), (int)properties.DimensionSizes[properties.Rank - 1]);
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
     [Fact]
     public void CanWrite_Chunked_single_chunk_filtered()
     {


### PR DESCRIPTION
Closes #168

### Summary

Chunked datasets written by PureHDF cannot be opened by HDF5 2.x. `#164` fixed the stored datatype size in the version 4 chunked data layout message, but a second field in the same message is also hardcoded, and it fails the same way:

```
H5D__chunk_set_sizes(): stored chunk dimension encoding length
                        does not match value calculated from chunk dimensions
```

HDF5 1.14 does not validate this field, which is why it goes unnoticed there.

### Reproducer

No filter or compound type needed — a plain `double[]` with explicit chunks is enough:

```csharp
new H5File { ["chunked"] = new H5Dataset(new double[100], chunks: [50]) }.Write("repro.h5");
```

```
$ h5ls repro.h5          # HDF5 2.1.1
chunked                  Dataset *ERROR*

$ h5dump -H repro.h5
h5dump error: internal error (h5dump.c:line 1555)
```

A contiguous dataset from the same version opens fine, so this is specific to the chunked layout. Any configured filter also forces the chunked layout, so filtered datasets are affected too.

### Cause

`ChunkedStoragePropertyDescription4.Encode` writes `driver.Write((byte)8)` for the dimension size encoded length and then writes each dimension as a full `ulong`. That is internally consistent, and PureHDF reads its own output back correctly, but HDF5 recomputes the field in `H5D__chunk_set_sizes()` and rejects any mismatch:

```c
/* Compute number of bytes to use for encoding chunk dimensions */
max_enc_bytes_per_dim = 0;
for (u = 0; u < (unsigned)dset->shared->layout.u.chunk.ndims; u++) {
    enc_bytes_per_dim = (H5VM_log2_gen(dset->shared->layout.u.chunk.dim[u]) + 8) / 8;
    if (enc_bytes_per_dim > max_enc_bytes_per_dim)
        max_enc_bytes_per_dim = enc_bytes_per_dim;
}
...
if (dset->shared->layout.u.chunk.enc_bytes_per_dim != max_enc_bytes_per_dim)
    HGOTO_ERROR(..., "stored chunk dimension encoding length does not match ...");
```

So the field must be the **minimum** width that can hold the largest dimension size — including the last dimension, which holds the datatype size. Note this permits widths of 3, 5, 6 and 7: a chunk dimension of 65536 requires 3 bytes, not 4. Rounding up to a power of two is not sufficient.

### Fix

Compute the width from the dimension sizes and write each dimension at that width via the existing `WriteUtils.WriteUlongArbitrary`. `GetEncodeSize` is updated to match. The decode path already handled arbitrary widths, so round-tripping is unaffected.

### Verification

- The reproducer above, plus chunk dimensions of 300 and 70000 (encoded lengths 2 and 3), and a deflate-filtered dataset: all open under `h5ls`/`h5dump` 2.1.1, read correctly under libhdf5 **2.0.0** (h5py 3.16.0) *and* **1.14.6** (h5py 3.15.1), and round-trip through PureHDF. The unpatched equivalents fail under both 2.0.0 and 2.1.1 and succeed only under 1.14.6 — the validation was added in 2.0.0.
- Byte-level check: the written encoded length matches HDF5's formula for every case tested, including the 3-byte one.
- **Existing tests in this repo already cover this** and are currently failing under HDF5 2.x, because `TestUtils.DumpH5File` shells out to `h5dump`. Run in isolation on `dev` vs this branch:

  | | `dev` | this branch |
  |---|---|---|
  | `Writing.DatasetTests` (chunked) | 7 failed, 1 passed | **8 passed** |
  | `Filters.FilterTests` | 6 failed, 166 passed | **172 passed** |

  I assume CI currently runs an HDF5 1.x, where the malformed field is ignored.

### Test added

`CanWrite_Chunked_StoresMinimalDimensionSizeEncodedLength`, a `Theory` over encoded lengths 1–4. It asserts the computed width directly rather than via `h5dump`, so it catches regressions regardless of which HDF5 version is installed — complementing the existing dump-comparison tests. Verified to fail (4/4) when the hardcoded width is restored.

This required widening `DimensionSizeEncodedLength` from `private` to `internal`; happy to drop the test or use reflection instead if you would rather keep it private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

