### PR TITLE
fix(reading): never decode strings as ASCII

### DIFF
--- a/src/PureHDF/Utils/ReadUtils.cs
+++ b/src/PureHDF/Utils/ReadUtils.cs
@@ -170,29 +170,32 @@ internal static partial class ReadUtils
         return array;
     }
 
-    public static string ReadFixedLengthString(Span<byte> data, CharacterSetEncoding encoding = CharacterSetEncoding.ASCII)
+    /* Strings are always decoded as UTF-8, never as ASCII.
+     *
+     * H5T_cset_t defines only H5T_CSET_ASCII and H5T_CSET_UTF8, and ASCII is a strict
+     * subset of UTF-8 — all 128 ASCII byte values decode identically under both — so a
+     * UTF-8 decoder is correct for every conformant payload, including the fields the
+     * format specification fixes as ASCII (filter names, driver identifiers, dates).
+     *
+     * Where the two differ is a payload that holds UTF-8 while being declared, or defaulted
+     * to, ASCII — which is what any writer that does not set a character set produces.
+     * There, Encoding.ASCII replaces every byte >= 0x80 with '?' silently and
+     * irrecoverably, and leaves the result indistinguishable from a literal '?'. UTF-8
+     * recovers such a payload, and marks genuinely malformed bytes U+FFFD.
+     */
+    public static string ReadFixedLengthString(Span<byte> data)
     {
-        return encoding switch
-        {
-            CharacterSetEncoding.ASCII => Encoding.ASCII.GetString(data),
-            CharacterSetEncoding.UTF8 => Encoding.UTF8.GetString(data),
-            _ => throw new FormatException($"The character set encoding '{encoding}' is not supported.")
-        };
+        return Encoding.UTF8.GetString(data);
     }
 
-    public static string ReadFixedLengthString(H5DriverBase driver, int length, CharacterSetEncoding encoding = CharacterSetEncoding.ASCII)
+    public static string ReadFixedLengthString(H5DriverBase driver, int length)
     {
         var data = driver.ReadBytes(length);
 
-        return encoding switch
-        {
-            CharacterSetEncoding.ASCII => Encoding.ASCII.GetString(data),
-            CharacterSetEncoding.UTF8 => Encoding.UTF8.GetString(data),
-            _ => throw new FormatException($"The character set encoding '{encoding}' is not supported.")
-        };
+        return Encoding.UTF8.GetString(data);
     }
 
-    public static string ReadNullTerminatedString(H5DriverBase driver, bool pad, int padSize = 8, CharacterSetEncoding encoding = CharacterSetEncoding.ASCII)
+    public static string ReadNullTerminatedString(H5DriverBase driver, bool pad, int padSize = 8)
     {
         var data = new List<byte>();
         var byteValue = driver.ReadByte();
@@ -203,17 +206,15 @@ internal static partial class ReadUtils
             byteValue = driver.ReadByte();
         }
 
-        var destination = encoding switch
-        {
-            CharacterSetEncoding.ASCII => Encoding.ASCII.GetString(data.ToArray()),
-            CharacterSetEncoding.UTF8 => Encoding.UTF8.GetString(data.ToArray()),
-            _ => throw new FormatException($"The character set encoding '{encoding}' is not supported.")
-        };
+        var destination = Encoding.UTF8.GetString(data.ToArray());
 
         if (pad)
         {
+            // The padding is measured from the bytes on disk, not from the decoded string:
+            // a multi-byte character makes the string shorter than the data it came from,
+            // which would seek to the wrong offset and desynchronise the driver.
             // https://stackoverflow.com/questions/20844983/what-is-the-best-way-to-calculate-number-of-padding-bytes
-            var paddingCount = (padSize - (destination.Length + 1) % padSize) % padSize;
+            var paddingCount = (padSize - (data.Count + 1) % padSize) % padSize;
             driver.Seek(paddingCount, SeekOrigin.Current);
         }
 

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Attribute/AttributeMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Attribute/AttributeMessage.Reading.cs
@@ -50,19 +50,19 @@ internal partial record class AttributeMessage(
         var dataspaceSize = context.Driver.ReadUInt16();
 
         // name character set encoding
-        var nameEncoding = default(CharacterSetEncoding);
-
+        // The field is consumed to keep the driver aligned but not acted upon: names are
+        // decoded as UTF-8 either way, which is correct for ASCII too. See ReadUtils.
         if (version == 3)
-            nameEncoding = (CharacterSetEncoding)context.Driver.ReadByte();
+            _ = context.Driver.ReadByte();
 
         // name
         string name;
 
         if (version == 1)
-            name = ReadUtils.ReadNullTerminatedString(context.Driver, pad: true, encoding: nameEncoding);
+            name = ReadUtils.ReadNullTerminatedString(context.Driver, pad: true);
 
         else
-            name = ReadUtils.ReadNullTerminatedString(context.Driver, pad: false, encoding: nameEncoding);
+            name = ReadUtils.ReadNullTerminatedString(context.Driver, pad: false);
 
         // datatype
         var flags1 = flags.HasFlag(AttributeMessageFlags.SharedDatatype)

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
@@ -958,6 +958,8 @@ internal partial record class DatatypeMessage(
 
             source.ReadDataset(memory.Span);
 
+            // Decoded as UTF-8, which is correct for H5T_CSET_ASCII too, and matches
+            // GetDecodeInfoForVariableLengthString. See ReadUtils.
             var value = ReadUtils.ReadFixedLengthString(memory.Span);
             value = trim(value);
 

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Link/LinkInfos.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Link/LinkInfos.cs
@@ -40,6 +40,10 @@ internal record class SoftLinkInfo(
     public static SoftLinkInfo Decode(H5DriverBase driver)
     {
         var valueLength = driver.ReadUInt16();
+
+        // The value has no character set field of its own and is a path made of link names,
+        // which may be UTF-8; decoded as ASCII it no longer names the object it points at
+        // and the link silently fails to resolve. Encode below writes UTF-8.
         var value = ReadUtils.ReadFixedLengthString(driver, valueLength);
 
         return new SoftLinkInfo(

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Link/LinkMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Link/LinkMessage.Reading.cs
@@ -48,17 +48,17 @@ internal partial record class LinkMessage(
             creationOrder = driver.ReadUInt64();
 
         // link name encoding
-        var linkNameEncoding = default(CharacterSetEncoding);
-
+        // The field is consumed to keep the driver aligned but not acted upon: names are
+        // decoded as UTF-8 either way, which is correct for ASCII too. See ReadUtils.
         if (flags.HasFlag(LinkInfoFlags.LinkNameEncodingFieldIsPresent))
-            linkNameEncoding = (CharacterSetEncoding)driver.ReadByte();
+            _ = driver.ReadByte();
 
         // link length
         var linkLengthFieldLength = (ulong)(1 << ((byte)flags & 0x03));
         var linkNameLength = ReadUtils.ReadUlong(driver, linkLengthFieldLength);
 
         // link name
-        var linkName = ReadUtils.ReadFixedLengthString(driver, (int)linkNameLength, linkNameEncoding);
+        var linkName = ReadUtils.ReadFixedLengthString(driver, (int)linkNameLength);
 
         // link info
         LinkInfo linkInfo = linkType switch

--- a/tests/PureHDF.Tests/RoundTrip/DatasetTests@FixedLengthString.cs
+++ b/tests/PureHDF.Tests/RoundTrip/DatasetTests@FixedLengthString.cs
@@ -1,0 +1,89 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+
+namespace PureHDF.Tests.RoundTrip;
+
+public class FixedLengthStringRoundTripTests
+{
+    // ASCII, a 2-byte character, a 3-byte character and a 4-byte character.
+    private const string NonAscii = "5µm→x\U0001F600";
+
+    private static int Utf8Length => Encoding.UTF8.GetByteCount(NonAscii);
+
+    [Fact]
+    public void WriteAndReadFixedLengthStringDataset()
+    {
+        var actual = RoundTrip(
+            file => file["test"] = new string[] { NonAscii },
+            file => file.Dataset("test").Read<string[]>()[0]);
+
+        Assert.Equal(NonAscii, actual);
+    }
+
+    [Fact]
+    public void WriteAndReadFixedLengthStringCompoundMember()
+    {
+        var actual = RoundTrip(
+            file => file["test"] = new Row[] { new() { Text = NonAscii } },
+            file => file.Dataset("test").Read<Row[]>()[0].Text);
+
+        Assert.Equal(NonAscii, actual);
+    }
+
+    [Fact]
+    public void WriteAndReadFixedLengthStringAttribute()
+    {
+        var actual = RoundTrip(
+            file => file.Attributes["test"] = NonAscii,
+            file => file.Attribute("test").Read<string>());
+
+        Assert.Equal(NonAscii, actual);
+    }
+
+    /// <summary>
+    /// Guards the variable-length path, which already decoded UTF-8 and must keep doing so.
+    /// </summary>
+    [Fact]
+    public void WriteAndReadVariableLengthStringDataset()
+    {
+        var h5FileWrite = new H5File
+        {
+            ["test"] = new string[] { NonAscii }
+        };
+
+        var memoryStream = new MemoryStream();
+        h5FileWrite.Write(memoryStream);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        var actual = H5File.Open(memoryStream).Dataset("test").Read<string[]>()[0];
+
+        Assert.Equal(NonAscii, actual);
+    }
+
+    private static string RoundTrip(Action<H5File> arrange, Func<IH5Group, string> act)
+    {
+        // Arrange
+        var h5FileWrite = new H5File();
+        arrange(h5FileWrite);
+
+        var memoryStream = new MemoryStream();
+
+        // A non-zero DefaultStringLength is what makes every string in the file
+        // fixed-length rather than variable-length.
+        h5FileWrite.Write(memoryStream, new H5WriteOptions(
+            DefaultStringLength: Utf8Length,
+            FieldStringLengthMapper: _ => Utf8Length));
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        // Act
+        return act(H5File.Open(memoryStream));
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Row
+    {
+        public string Text;
+    }
+}

--- a/tests/PureHDF.Tests/RoundTrip/LinkTests@NonAsciiTarget.cs
+++ b/tests/PureHDF.Tests/RoundTrip/LinkTests@NonAsciiTarget.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+namespace PureHDF.Tests.RoundTrip;
+
+public class SoftLinkRoundTripTests
+{
+    [Theory]
+    [InlineData("PD")]              // ASCII, worked before
+    [InlineData("µA")]              // 2-byte
+    [InlineData("温度")]             // 3-byte
+    [InlineData("data\U0001F600")]  // 4-byte
+    public void CanFollowSoftLinkWithNonAsciiTarget(string target)
+    {
+        // Arrange
+        var h5FileWrite = new H5File
+        {
+            [target] = new H5Group { ["data"] = new H5Dataset(new int[] { 1, 2, 3 }) },
+            ["link"] = new H5SoftLink($"/{target}")
+        };
+
+        var memoryStream = new MemoryStream();
+        h5FileWrite.Write(memoryStream);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        var h5FileRead = H5File.Open(memoryStream);
+
+        // Act
+        var resolved = h5FileRead.Get("link");
+
+        // Assert
+        // The target group's own name decodes correctly because LinkMessage forwards its
+        // character set. The soft link's value is a path built from such names, so decoding
+        // it as ASCII leaves it naming an object that does not exist and the link resolves
+        // to an unresolved-link stub instead of the group.
+        Assert.True(h5FileRead.LinkExists(target), "the target group itself is missing");
+        Assert.Null((resolved as IH5UnresolvedLink)?.Reason);
+        Assert.IsAssignableFrom<IH5Group>(resolved);
+        Assert.NotNull(((IH5Group)resolved).Dataset("data"));
+    }
+}


### PR DESCRIPTION
Fixes #169.

## Problem

`ReadUtils.ReadFixedLengthString` and `ReadUtils.ReadNullTerminatedString` declared
`CharacterSetEncoding encoding = CharacterSetEncoding.ASCII`, and most call sites inherited that default. `Encoding.ASCII` replaces every byte `>= 0x80` with `?`, so any non-ASCII payload was corrupted on read — silently, irrecoverably, and indistinguishably from data that legitimately contains `?`.

Two observable failures, both reproduced against released 2.1.4 and against this PR's base commit:

**1. Fixed-length strings.** `"5µm→x😀"` (7 chars / 12 UTF-8 bytes) round-tripped through PureHDF:

| position | before | after |
|---|---|---|
| fixed-length dataset | `5??m???x????` | `5µm→x😀` |
| fixed-length compound member | `5??m???x????` | `5µm→x😀` |
| fixed-length attribute value | `5??m???x????` | `5µm→x😀` |
| variable-length (any position) | `5µm→x😀` | `5µm→x😀` |
| link name / attribute name | `5µm→x😀` | `5µm→x😀` |

The bytes on disk are valid UTF-8 and the datatype message declares `H5T_CSET_UTF8` — h5py reads the same files back correctly. Because the substitution is per *byte*, the string's length changes too (7 in, 12 out), so a caller doing its own width arithmetic also gets a wrong answer.

**2. Soft links with a non-ASCII target no longer resolve.** The link *name* decodes correctly, so the target is reachable directly while the link to it is broken:

```
ASCII target      target group present=True   soft link -> OK     (NativeGroup)
non-ASCII target  target group present=True   soft link -> BROKEN (Could not find part of the path '/??A'.)
```

Beyond those two, the same default silently applied to compound and enum member names, object comments, opaque tags, virtual-dataset source file and dataset paths, external link paths, and multi-file driver member names.

## Change

Remove the parameter; always decode UTF-8.

`H5T_cset_t` defines only `H5T_CSET_ASCII` and `H5T_CSET_UTF8`, and ASCII is a strict subset of UTF-8 — all 128 ASCII byte values decode identically under both and re-encode byte-identically — so this cannot change the result for a conformant payload, including the fields the format specification fixes as ASCII (filter names, driver identifiers, the old modification-time digits).

Where the two differ is a payload holding UTF-8 while *declared*, or defaulted, to ASCII — which is what any writer that does not set a character set produces. I checked that case with h5py-written files that declare `H5T_CSET_ASCII` while holding UTF-8 bytes: dispatching on the declared character set still returns `5??m???x`, while decoding UTF-8 returns `5µm→x`. That is why this removes the option rather than threading `bitField.Encoding` through — honouring the declaration would leave those files broken, and `Encoding.ASCII` has no case in which it is preferable. When bytes genuinely are malformed, UTF-8 yields U+FFFD, which is at least detectable.

It also matches `GetDecodeInfoForVariableLengthString`, which already hardcoded `Encoding.UTF8.GetString` — the reason variable-length strings were unaffected throughout.

Two details worth flagging for review:

- **`ReadNullTerminatedString` measured its padding from the decoded string's length**, not the bytes read. Those are equal only under ASCII, so switching to UTF-8 would have desynchronised the driver on any multi-byte character. It now counts bytes. This was a latent bug for any caller that passed UTF-8 explicitly with `pad: true`.
- **The character set fields are still read** (`_ = driver.ReadByte()`) to keep the driver aligned, and `CharacterSetEncoding` is still used on the write side, so the enum stays.

## Tests

Two new files in `tests/PureHDF.Tests/RoundTrip/`:

- `DatasetTests@FixedLengthString.cs` — fixed-length dataset, compound member and attribute round trips, plus a guard on the variable-length path so a future change cannot regress it.
- `LinkTests@NonAsciiTarget.cs` — soft link resolution across an ASCII control and 2-, 3- and 4-byte UTF-8 targets.

Against the base commit: **6 of 8 fail**; the 2 that pass are the variable-length guard and the ASCII control. With this change: 8/8, and the full suite is **518 passed, 0 failed, 10 skipped** (HSDS, no network) on a clean rebuild, no new warnings.

## Not addressed here

`Encoding.ASCII.GetBytes` is still used on the **write** side for compound member names, enum member names, opaque tags and filter names — so a non-ASCII name is destroyed on write, before any reader is involved. That is a separate change with a different risk profile (it alters what PureHDF produces), and `CompoundPropertyDescription.Encode` already carries your `// TODO is this really ASCII? The spec does not specify it but does it so for enumerated data type (there it is ASCII)`. Happy to open a follow-up issue or PR if you want it — it seemed like your call to make rather than mine.
