### PR TITLE
fix(writing): encode datatype names as UTF-8

### DIFF
--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypePropertyDescriptions.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypePropertyDescriptions.cs
@@ -193,8 +193,7 @@ internal record class CompoundPropertyDescription(
 
     public override ushort GetEncodeSize(uint typeSize)
     {
-        // TODO is this really ASCII? The spec does not specify it but does it so for enumerated data type (there it is ASCII)
-        var nameBytesCount = Name.Length + 1;
+        var nameBytesCount = Encoding.UTF8.GetByteCount(Name) + 1;
         var byteCount = MathUtils.FindMinByteCount(typeSize);
 
         var encodeSize =
@@ -208,8 +207,12 @@ internal record class CompoundPropertyDescription(
     public override void Encode(H5DriverBase driver, uint typeSize)
     {
         // name
-        // TODO is this really ASCII? The spec does not specify it but does it so for enumerated data type (there it is ASCII)
-        var nameBytes = Encoding.ASCII.GetBytes(Name);
+        // The specification gives a compound member name no character set field, and the
+        // reference library copies it as an opaque NUL-terminated byte string
+        // (H5MM_xstrdup in H5Odtype.c), so whatever bytes the caller supplied are stored.
+        // Real files therefore carry UTF-8 names: h5py writes "µA" as c2 b5 41 and both
+        // h5py and h5dump read it back intact. GetEncodeSize above counts the same bytes.
+        var nameBytes = Encoding.UTF8.GetBytes(Name);
         driver.Write(nameBytes);
         driver.Write((byte)0);
 
@@ -270,7 +273,7 @@ internal record class EnumerationPropertyDescription(
     {
         var encodeSize =
             BaseType.GetEncodeSize() +
-            Names.Aggregate(0, (sum, name) => sum + name.Length + 1) +
+            Names.Aggregate(0, (sum, name) => sum + Encoding.UTF8.GetByteCount(name) + 1) +
             Values.Aggregate(0, (sum, value) => sum + value.Length);
 
         return (ushort)encodeSize;
@@ -282,9 +285,13 @@ internal record class EnumerationPropertyDescription(
         BaseType.Encode(driver);
 
         // names
+        // The specification calls these ASCII, but the reference library stores them as
+        // opaque byte strings like compound member names and h5py round-trips UTF-8 through
+        // them, so encoding as ASCII would replace a caller's non-ASCII name with '?' while
+        // no reader requires it.
         foreach (var name in Names)
         {
-            var nameBytes = Encoding.ASCII.GetBytes(name);
+            var nameBytes = Encoding.UTF8.GetBytes(name);
             driver.Write(nameBytes);
             driver.Write((byte)0);
         }
@@ -390,7 +397,8 @@ internal record class OpaquePropertyDescription(
 
     public override ushort GetEncodeSize(uint typeSize)
     {
-        var unpaddedLength = Tag.Length + 1;
+        // Counted in bytes, since that is what the limit and the padding are measured in.
+        var unpaddedLength = Encoding.UTF8.GetByteCount(Tag) + 1;
 
         if (unpaddedLength > byte.MaxValue)
             throw new Exception($"The maximum opaque tag length is {byte.MaxValue - 1} bytes");
@@ -400,7 +408,7 @@ internal record class OpaquePropertyDescription(
 
     public override void Encode(H5DriverBase driver, uint typeSize)
     {
-        var bytes = Encoding.ASCII.GetBytes(Tag);
+        var bytes = Encoding.UTF8.GetBytes(Tag);
         var length = bytes.Length + 1;
         var padBytesCount = MathUtils.Ceil_N(length, 8) - length;
 

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/FilterPipeline/FilterDescription.Writing.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/FilterPipeline/FilterDescription.Writing.cs
@@ -14,7 +14,7 @@ internal readonly partial record struct FilterDescription
             (isUnknown ? 2 : 0) +
             sizeof(ushort) +
             sizeof(ushort) +
-            (isUnknown ? Name.Length : 0) +
+            (isUnknown ? Encoding.UTF8.GetByteCount(Name) : 0) +
             sizeof(uint) * ClientData.Length;
 
         return (ushort)size;
@@ -31,7 +31,7 @@ internal readonly partial record struct FilterDescription
         // name length
         if (isUnknown)
         {
-            identifierBytes = Encoding.ASCII.GetBytes(Name);
+            identifierBytes = Encoding.UTF8.GetBytes(Name);
             driver.Write((ushort)identifierBytes.Count());
         }
 

--- a/tests/PureHDF.Tests/Writing/DatatypeTests@NonAsciiNames.cs
+++ b/tests/PureHDF.Tests/Writing/DatatypeTests@NonAsciiNames.cs
@@ -1,0 +1,106 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace PureHDF.Tests.Writing;
+
+/// <summary>
+/// A compound member name has no character set field in the specification, and the reference
+/// library copies it as an opaque NUL-terminated byte string (<c>H5MM_xstrdup</c> in
+/// <c>H5Odtype.c</c>), so real files carry UTF-8 names — h5py writes <c>"µA"</c> as
+/// <c>c2 b5 41</c> and both h5py and h5dump read it back intact. Encoding it as ASCII replaces
+/// every byte >= 0x80 with <c>'?'</c>, destroying the name before any reader is involved.
+/// <para>These assertions go through h5dump rather than PureHDF's own reader, so they check
+/// what actually reached the file.</para>
+/// </summary>
+[Collection(SharedHdf5StateCollection.Name)]
+public class NonAsciiNameWritingTests
+{
+    [Fact]
+    public void CanWrite_CompoundMemberName_WithNonAsciiCharacters()
+    {
+        var file = new H5File
+        {
+            ["compound"] = new Row[] { new() { First = 1.0, Second = 2, Third = 3 } }
+        };
+
+        var dump = Dump(file, Mapper);
+
+        Assert.Contains("µA", dump);
+        Assert.Contains("°C", dump);
+        Assert.Contains("→", dump);
+        Assert.DoesNotContain("?", dump);
+    }
+
+    [Fact]
+    public void CanWrite_EnumerationMemberName_WithNonAsciiCharacters()
+    {
+        var file = new H5File
+        {
+            ["enumeration"] = new[] { Unit.µA }
+        };
+
+        var dump = Dump(file, fieldNameMapper: null);
+
+        Assert.Contains("µA", dump);
+        Assert.DoesNotContain("?", dump);
+    }
+
+    [Fact]
+    public void CanWrite_OpaqueTag_WithNonAsciiCharacters()
+    {
+        var data = new byte[] { 0x01, 0x02, 0x03 };
+
+        var file = new H5File
+        {
+            ["opaque"] = new H5Dataset(data, opaqueInfo: new H5OpaqueInfo((uint)data.Length, "µA"))
+        };
+
+        var dump = Dump(file, fieldNameMapper: null);
+
+        Assert.Contains("µA", dump);
+        Assert.DoesNotContain("?", dump);
+    }
+
+    // Each of these names is one byte longer than its character count, so a size computed
+    // from the character count under-declares the datatype message and the members that
+    // follow are misplaced. h5dump then reports a malformed file rather than agreeing.
+    private static string? Mapper(FieldInfo fieldInfo) => fieldInfo.Name switch
+    {
+        nameof(Row.First) => "µA",
+        nameof(Row.Second) => "°C",
+        nameof(Row.Third) => "→",
+        _ => null
+    };
+
+    private static string Dump(H5File file, Func<FieldInfo, string?>? fieldNameMapper)
+    {
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            file.Write(filePath, new H5WriteOptions(FieldNameMapper: fieldNameMapper!));
+
+            return TestUtils.DumpH5File(filePath)
+                ?? throw new Exception("h5dump produced no output.");
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Row
+    {
+        public double First;
+        public int Second;
+        public short Third;
+    }
+
+    private enum Unit
+    {
+        µA = 0
+    }
+}


### PR DESCRIPTION
Independent of #170 — that one is the read path, this one is the write path. Neither depends on the other, and they touch different files.

## Problem

Compound member names, enumeration member names, opaque tags and unknown-filter names are written with `Encoding.ASCII.GetBytes`, which replaces every byte `>= 0x80` with `?`. A non-ASCII name is therefore destroyed **on write**, before any reader is involved, and the file keeps no trace of the original.

`CompoundPropertyDescription` carries a TODO asking exactly this:

```csharp
// TODO is this really ASCII? The spec does not specify it but does it so for enumerated data type (there it is ASCII)
```

I went looking for the answer, and it is no:

- **The specification gives a compound member name no character set field**, and the reference library copies it as an opaque NUL-terminated byte string — `H5MM_xstrdup((const char *)*pp)` in `H5Odtype.c` — so whatever bytes the caller supplied are stored, and whatever bytes are on disk are returned. There is no conversion step in which an encoding could be applied.
- **Real files carry UTF-8.** h5py writes a compound member named `µA` and an enumeration member named `µA` as `c2 b5 41`; the file contains those bytes twice and no `?A` at all, and h5py, the C library and `h5dump` all read them back intact:

```
DATATYPE  H5T_COMPOUND {
   H5T_IEEE_F64LE "µA";
   H5T_STD_I32LE "ok";
}
```

Enumeration names *are* documented as ASCII, which is what the TODO refers to. But they are stored the same way, no reader requires it, and h5py round-trips UTF-8 through them — so encoding them as ASCII only discards data that would otherwise survive. I have written them as UTF-8 for consistency; say the word if you would rather they stayed strict, in which case throwing on non-ASCII input would at least beat silently substituting `?`.

## The part that needs review

**Every `GetEncodeSize` is changed alongside its `Encode`.** The sizes were computed from the string's *character* count:

```csharp
var nameBytesCount = Name.Length + 1;                                   // before
var nameBytesCount = Encoding.UTF8.GetByteCount(Name) + 1;              // after
```

Character count equals byte count only under ASCII. Changing `Encode` alone would under-declare the datatype message for any multi-byte character and misplace every member after it — a corrupt file rather than a mangled name. So the two have to move together, and this is the reason the diff is slightly wider than the one-line-per-site it looks like it should be. The opaque tag's `byte.MaxValue` limit and its 8-byte padding are likewise now measured in bytes.

Sites changed: `CompoundPropertyDescription`, `EnumerationPropertyDescription`, `OpaquePropertyDescription`, `FilterDescription`.

Left as they are: the 22 `Encoding.ASCII.GetBytes("OHDR")`-style magic signatures, and `MathUtils.ValidateSignature`'s error formatting — those are ASCII literals and correct.

## Tests

`tests/PureHDF.Tests/Writing/DatatypeTests@NonAsciiNames.cs` — compound member names, an enumeration member name and an opaque tag, all non-ASCII.

The assertions go through `TestUtils.DumpH5File` rather than PureHDF's own reader, deliberately: they check what actually reached the file, so they neither depend on nor are masked by the read path in #170. The compound case uses three members with 2-, 2- and 3-byte names so that a size computed from character counts misplaces the members and `h5dump` reports a malformed file instead of quietly agreeing.

All 3 fail on the base commit and pass with this change. Full suite: **513 passed, 0 failed, 10 skipped** (HSDS, no network) on a clean rebuild, no new warnings.
