### PR TITLE
fix(writing): key the datatype cache by everything the message depends on

### DIFF
--- a/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
@@ -1,5 +1,19 @@
 namespace PureHDF.VOL.Native;
 
+/// <summary>
+/// Identifies a cached datatype message. A <see cref="Type"/> alone is not enough: a string's
+/// width and an opaque type's size and tag are supplied by the caller, so one type maps to many
+/// messages. Everything that varies is part of the key, which is what makes the cache safe to
+/// read for those types rather than having to skip them.
+/// </summary>
+/// <param name="Type">The .NET type being encoded.</param>
+/// <param name="StringLength">The requested fixed-width string length; 0 means variable-length.</param>
+/// <param name="OpaqueInfo">The opaque size and tag, when encoding an opaque type.</param>
+internal readonly record struct DatatypeCacheKey(
+    Type Type,
+    int StringLength,
+    H5OpaqueInfo? OpaqueInfo);
+
 internal record NativeWriteContext(
     H5NativeWriter Writer,
     H5File File,
@@ -9,7 +23,7 @@ internal record NativeWriteContext(
     H5WriteOptions WriteOptions,
     Dictionary<H5Dataset, (H5D_Base H5D, object Encode)> DatasetToInfoMap,
     Dictionary<DatasetInfo, (long ObjectHeaderStart, int ObjectHeaderLength)> DatasetInfoToObjectHeaderMap,
-    Dictionary<Type, (DatatypeMessage, ElementEncodeDelegate)> TypeToMessageMap,
+    Dictionary<DatatypeCacheKey, (DatatypeMessage, ElementEncodeDelegate)> TypeToMessageMap,
     Dictionary<H5Object, ulong> ObjectToAddressMap,
     Dictionary<H5Object, int> ObjectReferenceCountMap,
     Dictionary<object, H5Dataset> RawValueToDatasetMap,

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Writing.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Writing.cs
@@ -109,27 +109,15 @@ internal partial record class DatatypeMessage : Message
         if (type == typeof(byte) && opaqueInfo is not null)
             type = typeof(H5OpaqueInfo);
 
-        // Cache
+        // Cache. The key is the type plus everything else the message depends on — a string's
+        // requested width, an opaque type's size and tag — because those come from the caller,
+        // so one type maps to many messages. Keying on all of it means strings and opaque types
+        // can be cached like anything else instead of having to be excluded.
         var cache = context.TypeToMessageMap;
-        
-        {
-            // Cannot use cache for string as the 'stringLength' can be different for each instance of the type
-            if (type == typeof(string) && stringLength != default)
-            {
-                //    
-            }
+        var cacheKey = new DatatypeCacheKey(type, stringLength, opaqueInfo);
 
-            // Cannot use cache for H5OpaqueInfo as the size can be different for each instance of the type
-            else if (type == typeof(H5OpaqueInfo))
-            {
-                //
-            }
-
-            else if (cache.TryGetValue(type, out var cachedMessage))
-            {
-                return cachedMessage;
-            }
-        }
+        if (cache.TryGetValue(cacheKey, out var cachedMessage))
+            return cachedMessage;
 
         //
         var endianness = BitConverter.IsLittleEndian
@@ -231,7 +219,7 @@ internal partial record class DatatypeMessage : Message
             _ => throw new NotSupportedException($"The data type '{type}' is not supported."),
         };
 
-        cache[type] = (newMessage, encode);
+        cache[cacheKey] = (newMessage, encode);
 
         return (newMessage, encode);
     }

--- a/tests/PureHDF.Tests/Writing/DatatypeTests@Cache.cs
+++ b/tests/PureHDF.Tests/Writing/DatatypeTests@Cache.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace PureHDF.Tests.Writing;
+
+/// <summary>
+/// The write-side datatype cache is keyed by everything a message depends on, not by
+/// <see cref="Type"/> alone. A string's width and an opaque type's size and tag come from the
+/// caller, so one type maps to many messages; keying only by type let one instance's width be
+/// handed to another's.
+/// </summary>
+public class DatatypeCacheTests
+{
+    private const string Long = "a-value-that-is-much-longer-than-three-characters";
+
+    /// <summary>
+    /// A fixed-width string compound member and a variable-length string attribute are both
+    /// <c>typeof(string)</c>. Encoding order matters: the attribute on the group before the
+    /// dataset is written first and was always correct, so the defect hid behind it.
+    /// </summary>
+    [Fact]
+    public void CanWrite_StringAttribute_AfterANarrowFixedLengthStringMember()
+    {
+        var before = new H5Group();
+        before.Attributes["text"] = Long;
+
+        var after = new H5Group();
+        after.Attributes["text"] = Long;
+
+        var file = new H5File
+        {
+            ["a_before"] = before,
+            ["b_table"] = new H5Group { ["table"] = new Row[] { new() { Unit = "Ohm" } } },
+            ["c_after"] = after,
+        };
+
+        var (actualBefore, actualAfter) = RoundTrip(
+            file,
+            new H5WriteOptions(FieldStringLengthMapper: _ => 3),
+            f => (f.Group("a_before").Attribute("text").Read<string>(),
+                  f.Group("c_after").Attribute("text").Read<string>()));
+
+        Assert.Equal(Long, actualBefore);
+        Assert.Equal(Long, actualAfter);
+    }
+
+    /// <summary>Two widths for one type must not collapse into one message.</summary>
+    [Fact]
+    public void CanWrite_TwoFixedLengthStringMembers_OfDifferentWidths()
+    {
+        var file = new H5File
+        {
+            ["table"] = new WideRow[] { new() { Narrow = "abc", Wide = Long } }
+        };
+
+        static int? mapper(FieldInfo fieldInfo) =>
+            fieldInfo.Name == nameof(WideRow.Narrow) ? 3 : Long.Length;
+
+        var actual = RoundTrip(
+            file,
+            new H5WriteOptions(FieldStringLengthMapper: mapper),
+            f => f.Dataset("table").Read<WideRow[]>()[0]);
+
+        Assert.Equal("abc", actual.Narrow);
+        Assert.Equal(Long, actual.Wide);
+    }
+
+    /// <summary>
+    /// Opaque messages carry a size and a tag, so two opaque datasets differing in either must
+    /// not share a cache entry.
+    /// </summary>
+    [Fact]
+    public void CanWrite_TwoOpaqueDatasets_OfDifferentSizesAndTags()
+    {
+        var two = new byte[] { 1, 2 };
+        var three = new byte[] { 1, 2, 3 };
+
+        var file = new H5File
+        {
+            ["first"] = new H5Dataset(two, opaqueInfo: new H5OpaqueInfo((uint)two.Length, "TagA")),
+            ["second"] = new H5Dataset(three, opaqueInfo: new H5OpaqueInfo((uint)three.Length, "TagB")),
+        };
+
+        var (firstSize, secondSize) = RoundTrip(
+            file,
+            new H5WriteOptions(),
+            f => (f.Dataset("first").Type.Size, f.Dataset("second").Type.Size));
+
+        Assert.Equal(two.Length, firstSize);
+        Assert.Equal(three.Length, secondSize);
+    }
+
+    private static T RoundTrip<T>(H5File file, H5WriteOptions options, Func<IH5Group, T> act)
+    {
+        var memoryStream = new MemoryStream();
+        file.Write(memoryStream, options);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        return act(H5File.Open(memoryStream));
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Row
+    {
+        public string Unit;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WideRow
+    {
+        public string Narrow;
+        public string Wide;
+    }
+}


### PR DESCRIPTION
Fixes #172. Independent of #170 (read path) and #171 (name encoding) — different files, no ordering between them.

## Change

Key the write-side datatype cache by everything the message depends on, rather than by `Type` alone:

```csharp
internal readonly record struct DatatypeCacheKey(
    Type Type,
    int StringLength,
    H5OpaqueInfo? OpaqueInfo);
```

`GetTypeInfoForScalar` then does one unconditional lookup and one unconditional store, and the two "cannot use cache for …" special cases go away:

```diff
-        {
-            // Cannot use cache for string as the 'stringLength' can be different for each instance of the type
-            if (type == typeof(string) && stringLength != default) { }
-            // Cannot use cache for H5OpaqueInfo as the size can be different for each instance of the type
-            else if (type == typeof(H5OpaqueInfo)) { }
-            else if (cache.TryGetValue(type, out var cachedMessage)) { return cachedMessage; }
-        }
+        var cacheKey = new DatatypeCacheKey(type, stringLength, opaqueInfo);
+
+        if (cache.TryGetValue(cacheKey, out var cachedMessage))
+            return cachedMessage;
```

Those comments were right about the problem — the bug was that the *store* did not honour them, so the entry the lookup avoided reading was still written and a caller that took the lookup read it. Keying on the pair fixes that and additionally lets strings and opaque types be cached, where before they were excluded from the cache entirely.

`H5OpaqueInfo` is included rather than just its size because it is a record and the **tag** is part of the message too — size alone would not distinguish two same-sized opaque types with different tags.

## Tests

`tests/PureHDF.Tests/Writing/DatatypeTests@Cache.cs`, three cases:

1. **A string attribute after a narrow fixed-width string member** — the reported defect. Asserts both the attribute on the group *before* the dataset and the one *after* it, because encoding order is what decided whether a value survived. **Fails on `dev`** (`'a-v'` instead of 63 characters).
2. **Two fixed-width string members of different widths in one compound.**
3. **Two opaque datasets differing in size and tag.**

Being straightforward about 2 and 3: **they pass on `dev` as well.** They pin behaviour that `dev` achieves by skipping the cache and this change achieves by keying it — so they are guards on the caching this PR adds, not reproducers of the bug. Only case 1 demonstrates the defect.

Full suite: **513 passed, 0 failed, 10 skipped** (HSDS, no network) on a clean rebuild, no new warnings.

## Context for why this went unnoticed

A non-zero `DefaultStringLength` sidesteps the whole thing, because attributes then also satisfy `stringLength != default` and no string path ever consults the cache. The defect therefore only appears when per-member widths are used with the default options — which is the configuration `FieldStringLengthMapper` exists for. In a real file of ours, 119 of 120 group attributes were truncated to the width of a 3-character unit column, and the first one was correct, so it survived every spot check until the values were compared against their source.
