### PR TITLE
fix(reading): partial stream reads, cache thread safety, and group header re-decode

### DIFF
--- a/src/PureHDF/Utils/StreamExtensions.cs
+++ b/src/PureHDF/Utils/StreamExtensions.cs
@@ -11,6 +11,13 @@ internal static partial class StreamExtensions
         while (slicedBuffer.Length > 0)
         {
             var readBytes = stream.Read(slicedBuffer);
+
+            // Read returns 0 only at end of stream, so without this a truncated file spins here
+            // forever instead of failing. Matches what Stream.ReadExactly does on net8.0+, which is
+            // what this shim stands in for.
+            if (readBytes == 0)
+                throw new EndOfStreamException();
+
             slicedBuffer = slicedBuffer[readBytes..];
         };
     }

--- a/src/PureHDF/VFD/H5StreamDriver.Reading.cs
+++ b/src/PureHDF/VFD/H5StreamDriver.Reading.cs
@@ -50,13 +50,11 @@ internal partial class H5StreamDriver : H5DriverBase
 
         else
         {
-            var remainingBuffer = buffer;
-
-            while (remainingBuffer.Length > 0)
-            {
-                var count = _stream.Read(buffer);
-                remainingBuffer = remainingBuffer[count..];
-            }
+            // This used to loop itself, advancing a `remainingBuffer` while still passing the
+            // ORIGINAL buffer to Read - so a stream that returned a partial read restarted at offset
+            // zero, overwriting bytes it had already delivered while the loop counted them as
+            // progress. Silently wrong data, no exception. ReadExactly does the same loop correctly.
+            _stream.ReadExactly(buffer);
         }
     }
 
@@ -103,7 +101,11 @@ internal partial class H5StreamDriver : H5DriverBase
     {
         var size = Unsafe.SizeOf<T>();
         Span<byte> buffer = stackalloc byte[size];
-        _stream.Read(buffer);
+
+        // ReadExactly, not Read: Read's return value was discarded, so a stream that delivered fewer
+        // bytes than asked left the rest of the value as whatever the stack slot held. Every length,
+        // address and checksum in the file goes through here.
+        _stream.ReadExactly(buffer);
 
         return MemoryMarshal.Cast<byte, T>(buffer)[0];
     }

--- a/src/PureHDF/VFD/H5StreamDriver.Reading.cs
+++ b/src/PureHDF/VFD/H5StreamDriver.Reading.cs
@@ -44,18 +44,10 @@ internal partial class H5StreamDriver : H5DriverBase
     public override void ReadDataset(Span<byte> buffer)
     {
         if (_stream is IDatasetStream datasetStream)
-        {
             datasetStream.ReadDataset(buffer);
-        }
 
         else
-        {
-            // This used to loop itself, advancing a `remainingBuffer` while still passing the
-            // ORIGINAL buffer to Read - so a stream that returned a partial read restarted at offset
-            // zero, overwriting bytes it had already delivered while the loop counted them as
-            // progress. Silently wrong data, no exception. ReadExactly does the same loop correctly.
             _stream.ReadExactly(buffer);
-        }
     }
 
     public override void Read(Span<byte> buffer)

--- a/src/PureHDF/VOL/Native/API.Reading/NativeGroup.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeGroup.cs
@@ -140,15 +140,35 @@ public class NativeGroup : NativeObject, IH5Group
         var segments = isRooted ? path.Split('/').Skip(1).ToArray() : path.Split('/');
         var current = isRooted ? Context.File.Reference : Reference;
 
+        // The first hop of a RELATIVE path is this group, whose object header is already decoded and
+        // held. Dereferencing our own reference to get it - which is what this did - builds a second
+        // NativeGroup and decodes that header again, from the file, on every lookup.
+        //
+        // The cost is proportional to the number of LINKS, not to the depth of the path, because a
+        // group that stores its links compactly keeps one header message per link: measured on a
+        // 1000-link group written by PureHDF's own writer, one LinkExists re-read 30,113 bytes and
+        // allocated 2.1 MB, and 2000 links doubled both. A lookup that missed cost exactly as much as
+        // one that hit, since the whole cost was the re-decode rather than the search.
+        //
+        // Only the first iteration can reuse a group we already hold; every later segment names an
+        // object not yet resolved, so this is cleared at the end of each pass.
+        var group = isRooted ? null : this;
+
         for (int i = 0; i < segments.Length; i++)
         {
-            if (current.Dereference() is not NativeGroup group)
-                return false;
+            if (group is null)
+            {
+                if (current.Dereference() is not NativeGroup dereferenced)
+                    return false;
+
+                group = dereferenced;
+            }
 
             if (!group.TryGetReference(segments[i], linkAccess, out var reference))
                 return false;
 
             current = reference;
+            group = null;
         }
 
         return true;
@@ -163,16 +183,27 @@ public class NativeGroup : NativeObject, IH5Group
         var segments = isRooted ? path.Split('/').Skip(1).ToArray() : path.Split('/');
         var current = isRooted ? Context.File.Reference : Reference;
 
+        // See InternalLinkExists for why the first hop of a relative path reuses this group.
+        var group = isRooted ? null : this;
+
         for (int i = 0; i < segments.Length; i++)
         {
-            // TODO: Use cache to store dereferenced objects (as it is done in HsdsGroup.cs)
-            if (current.Dereference() is not NativeGroup group)
-                throw new Exception($"Path segment '{segments[i - 1]}' is not a group.");
+            if (group is null)
+            {
+                // TODO: Use cache to store dereferenced objects (as it is done in HsdsGroup.cs). That
+                // would cover the remaining case - the intermediate segments of a deep path, and the
+                // root of a rooted one - which still re-decode a header per lookup.
+                if (current.Dereference() is not NativeGroup dereferenced)
+                    throw new Exception($"Path segment '{segments[i - 1]}' is not a group.");
+
+                group = dereferenced;
+            }
 
             if (!group.TryGetReference(segments[i], linkAccess, out var reference))
                 throw new Exception($"Could not find part of the path '{path}'.");
 
             current = reference;
+            group = null;
         }
 
         return current;

--- a/src/PureHDF/VOL/Native/API.Reading/SimpleReadingChunkCache.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/SimpleReadingChunkCache.cs
@@ -16,6 +16,16 @@ public class SimpleReadingChunkCache : IReadingChunkCache
 
     private readonly Dictionary<ulong, ReadingChunkInfo> _chunkInfoMap = new();
 
+    // A caller may share one cache across concurrent reads by passing it via
+    // H5DatasetAccess.ChunkCache, and _chunkInfoMap plus the ConsumedBytes accounting were otherwise
+    // mutated with no synchronization. The default path never shares a cache - the default factory
+    // builds one per read - so this only ever bit callers who opted in, and it bit them silently.
+    //
+    // A lock is affordable here because of what it guards: a miss costs a chunk read and usually
+    // decompression, orders of magnitude more than the lock itself. It is deliberately NOT held
+    // across chunkReader() - see GetChunk.
+    private readonly object _lock = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SimpleReadingChunkCache"/> class.
     /// </summary>
@@ -41,7 +51,18 @@ public class SimpleReadingChunkCache : IReadingChunkCache
     /// <summary>
     /// Gets the number of chunk slots that have already been consumed.
     /// </summary>
-    public int ConsumedSlots => _chunkInfoMap.Count;
+    public int ConsumedSlots
+    {
+        get
+        {
+            // Reading Dictionary.Count while another reader mutates the dictionary is not safe, so
+            // this observation is synchronized too - it is a diagnostic, never on the read path.
+            lock (_lock)
+            {
+                return _chunkInfoMap.Count;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets the maximum size of the chunk cache in bytes.
@@ -54,19 +75,46 @@ public class SimpleReadingChunkCache : IReadingChunkCache
     public ulong ConsumedBytes { get; private set; }
 
     /// <inheritdoc />
+    /// <remarks>
+    ///     Safe to call concurrently. The lock is released around <paramref name="chunkReader" />:
+    ///     holding it across a chunk read (I/O plus decompression) would serialize every reader
+    ///     sharing this cache and so defeat the point of reading in parallel. The cost is that two
+    ///     readers missing on the same chunk at the same time both decode it and one result is
+    ///     discarded - wasted work, never incorrect.
+    ///     <para>
+    ///         Evicting a chunk another reader is still decoding from is likewise safe, but only
+    ///         because cached chunks are plain GC-allocated arrays (see H5D_Chunk.ReadChunk and
+    ///         H5Filter.ExecutePipeline): eviction drops a reference, and the holder's Memory keeps
+    ///         the array alive. Pooling cached chunks would break that, and a lock would then no
+    ///         longer be sufficient.
+    ///     </para>
+    /// </remarks>
     public Memory<byte> GetChunk(ulong chunkIndex, Func<Memory<byte>> chunkReader)
     {
-        if (_chunkInfoMap.TryGetValue(chunkIndex, out var chunkInfo))
+        lock (_lock)
         {
-            chunkInfo.LastAccess = Environment.TickCount64;
+            if (_chunkInfoMap.TryGetValue(chunkIndex, out var cached))
+            {
+                cached.LastAccess = Environment.TickCount64;
+
+                return cached.Chunk;
+            }
         }
 
-        else
+        var buffer = chunkReader();
+
+        lock (_lock)
         {
-            var buffer = chunkReader();
+            // Another reader may have installed this chunk while we were decoding it. Prefer the
+            // installed one, so every reader observes the same buffer for a given index.
+            if (_chunkInfoMap.TryGetValue(chunkIndex, out var installed))
+            {
+                installed.LastAccess = Environment.TickCount64;
 
-            chunkInfo = new ReadingChunkInfo(buffer) { LastAccess = Environment.TickCount64 };
+                return installed.Chunk;
+            }
 
+            var chunkInfo = new ReadingChunkInfo(buffer) { LastAccess = Environment.TickCount64 };
             var chunk = chunkInfo.Chunk;
 
             if ((ulong)chunk.Length <= ByteCount)
@@ -79,9 +127,9 @@ public class SimpleReadingChunkCache : IReadingChunkCache
                 ConsumedBytes += (ulong)chunk.Length;
                 _chunkInfoMap[chunkIndex] = chunkInfo;
             }
-        }
 
-        return chunkInfo.Chunk;
+            return chunk;
+        }
     }
 
     private void Preempt()

--- a/src/PureHDF/VOL/Native/API.Reading/SimpleReadingChunkCache.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/SimpleReadingChunkCache.cs
@@ -119,13 +119,22 @@ public class SimpleReadingChunkCache : IReadingChunkCache
 
             if ((ulong)chunk.Length <= ByteCount)
             {
-                while (_chunkInfoMap.Count >= ChunkSlotCount || ByteCount - ConsumedBytes < (ulong)chunk.Length)
+                // Nothing to preempt once the map is empty. Without that guard a cache constructed
+                // with zero slots - which the constructor allows, and which reads as "do not cache" -
+                // preempted an empty map and dereferenced the default KeyValuePair.
+                while (_chunkInfoMap.Count > 0 &&
+                      (_chunkInfoMap.Count >= ChunkSlotCount || ByteCount - ConsumedBytes < (ulong)chunk.Length))
                 {
                     Preempt();
                 }
 
-                ConsumedBytes += (ulong)chunk.Length;
-                _chunkInfoMap[chunkIndex] = chunkInfo;
+                // Re-checked rather than assumed: with slots available the loop above has already made
+                // room, but with none it exits on the emptiness guard and this chunk is not cacheable.
+                if (_chunkInfoMap.Count < ChunkSlotCount)
+                {
+                    ConsumedBytes += (ulong)chunk.Length;
+                    _chunkInfoMap[chunkIndex] = chunkInfo;
+                }
             }
 
             return chunk;

--- a/src/PureHDF/VOL/Native/Core.Reading/NativeCache.cs
+++ b/src/PureHDF/VOL/Native/Core.Reading/NativeCache.cs
@@ -8,8 +8,8 @@ internal static class NativeCache
 
     static NativeCache()
     {
-        _globalHeapMap = new ConcurrentDictionary<H5DriverBase, Dictionary<ulong, GlobalHeapCollection>>();
-        _fileMap = new ConcurrentDictionary<H5DriverBase, Dictionary<string, NativeFile>>();
+        _globalHeapMap = new ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<ulong, GlobalHeapCollection>>();
+        _fileMap = new ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<string, NativeFile>>();
     }
 
     #endregion
@@ -19,21 +19,15 @@ internal static class NativeCache
     public static void Clear(H5DriverBase driver)
     {
         // global heap
-        if (_globalHeapMap.ContainsKey(driver))
-            _globalHeapMap.TryRemove(driver, out var _);
-
+        _globalHeapMap.TryRemove(driver, out var _);
 
         // file map
-        if (_fileMap.TryGetValue(driver, out var value))
+        if (_fileMap.TryRemove(driver, out var pathToNativeFileMap))
         {
-            var pathToNativeFileMap = value;
-
             foreach (var nativeFile in pathToNativeFileMap.Values)
             {
                 nativeFile.Dispose();
             }
-
-            _fileMap.TryRemove(driver, out var _);
         }
     }
 
@@ -41,18 +35,19 @@ internal static class NativeCache
 
     #region Global Heap
 
-    private static readonly ConcurrentDictionary<H5DriverBase, Dictionary<ulong, GlobalHeapCollection>> _globalHeapMap;
+    private static readonly ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<ulong, GlobalHeapCollection>> _globalHeapMap;
 
     public static GlobalHeapCollection GetGlobalHeapObject(
         NativeReadContext context,
         ulong address,
         bool restoreAddress = false)
     {
-        if (!_globalHeapMap.TryGetValue(context.Driver, out var addressToCollectionMap))
-        {
-            addressToCollectionMap = new Dictionary<ulong, GlobalHeapCollection>();
-            _globalHeapMap.AddOrUpdate(context.Driver, addressToCollectionMap, (_, oldAddressToCollectionMap) => addressToCollectionMap);
-        }
+        // GetOrAdd rather than AddOrUpdate with a constant new value: the update lambda returned the
+        // freshly created map unconditionally, so when two readers both missed, one reader's map -
+        // and everything already decoded into it - was silently dropped.
+        var addressToCollectionMap = _globalHeapMap.GetOrAdd(
+            context.Driver,
+            static _ => new ConcurrentDictionary<ulong, GlobalHeapCollection>());
 
         if (!addressToCollectionMap.TryGetValue(address, out var collection))
         {
@@ -61,7 +56,9 @@ internal static class NativeCache
             context.Driver.SeekRelativeToBaseAddress((long)address);
             collection = GlobalHeapCollection.Decode(context);
 
-            addressToCollectionMap[address] = collection;
+            // Prefer whatever is already installed, so two readers that miss on the same collection
+            // converge on one instance instead of one of them discarding its work.
+            collection = addressToCollectionMap.GetOrAdd(address, collection);
 
             if (restoreAddress)
                 context.Driver.Seek(position, SeekOrigin.Begin);
@@ -74,7 +71,7 @@ internal static class NativeCache
 
     #region File Handles
 
-    private static readonly ConcurrentDictionary<H5DriverBase, Dictionary<string, NativeFile>> _fileMap;
+    private static readonly ConcurrentDictionary<H5DriverBase, ConcurrentDictionary<string, NativeFile>> _fileMap;
 
     public static NativeFile GetNativeFile(H5DriverBase driver, string absoluteFilePath)
     {
@@ -84,17 +81,21 @@ internal static class NativeCache
         if (!uri.IsFile && !uri.IsUnc)
             throw new Exception("The provided path is not a file path or a UNC path.");
 
-        if (!_fileMap.TryGetValue(driver, out var pathToNativeFileMap))
-        {
-            pathToNativeFileMap = new Dictionary<string, NativeFile>();
-            _fileMap.AddOrUpdate(driver, pathToNativeFileMap, (_, oldPathToNativeFileMap) => pathToNativeFileMap);
-        }
+        var pathToNativeFileMap = _fileMap.GetOrAdd(
+            driver,
+            static _ => new ConcurrentDictionary<string, NativeFile>());
 
         if (!pathToNativeFileMap.TryGetValue(uri.AbsoluteUri, out var nativeFile))
         {
             // TODO: This does not correspond to https://support.hdfgroup.org/HDF5/doc/RM/H5L/H5Lcreate_external.htm
-            nativeFile = H5File.Open(uri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            pathToNativeFileMap[uri.AbsoluteUri] = nativeFile;
+            var opened = H5File.Open(uri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            nativeFile = pathToNativeFileMap.GetOrAdd(uri.AbsoluteUri, opened);
+
+            // Losing the race means this handle is not the one anybody will use, and Clear only
+            // disposes what is in the map - so without this it would stay open until the process ends.
+            if (!ReferenceEquals(nativeFile, opened))
+                opened.Dispose();
         }
 
         return nativeFile;

--- a/tests/PureHDF.Tests/Reading/CacheConcurrencyTests.cs
+++ b/tests/PureHDF.Tests/Reading/CacheConcurrencyTests.cs
@@ -1,0 +1,105 @@
+using HDF.PInvoke;
+using PureHDF.Selections;
+using Xunit;
+
+namespace PureHDF.Tests.Reading;
+
+/// <summary>
+/// The reader supports concurrent reads through one file - see <see cref="ConcurrencyTests" /> - but
+/// two of its caches were mutated without synchronization while doing so.
+/// </summary>
+/// <remarks>
+/// These are stress tests, and they detect a data race probabilistically rather than deterministically:
+/// a corrupt dictionary is a consequence of unlucky interleaving, not of any particular call order. Both
+/// failed reliably within a few runs against the unsynchronized code and pass consistently with it
+/// fixed, which is the most a test of this shape can offer. What they do guarantee is the other
+/// direction: neither can fail once the mutations are synchronized.
+/// </remarks>
+[Collection(SharedHdf5StateCollection.Name)]
+public class CacheConcurrencyTests
+{
+    /// <summary>
+    /// A chunk cache shared across concurrent reads.
+    /// </summary>
+    /// <remarks>
+    /// The default path never shares one - the default factory builds a cache per read - so this is
+    /// reachable only by opting in through <see cref="H5DatasetAccess.ChunkCache" />, which is
+    /// precisely why it went unnoticed. Sharing a cache is also the only reason to pass one: it is
+    /// what makes repeated reads of the same chunks cheap.
+    /// </remarks>
+    [Fact]
+    public void SharedChunkCacheSurvivesConcurrentReads()
+    {
+        // Arrange
+        var version = H5F.libver_t.LATEST;
+        var filePath = TestUtils.PrepareTestFile(version, TestUtils.AddChunkedDataset_Huge);
+
+        using var root = NativeFile.InternalOpen(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            deleteOnClose: true);
+
+        // The H5DatasetAccess overload of Read is on NativeDataset, not on the IH5Dataset interface.
+        var dataset = (NativeDataset)root.Group("chunked").Dataset("chunked_huge");
+
+        // Big enough to hold every chunk touched below, so that eviction is not what is under test.
+        var sharedCache = new SimpleReadingChunkCache(chunkSlotCount: 512, byteCount: 64 * 1024 * 1024);
+        var datasetAccess = new H5DatasetAccess(ChunkCache: sharedCache);
+
+        const int CHUNK_SIZE = 1_000_000;
+
+        // Act - overlapping ranges, so readers contend for the SAME cache entries rather than each
+        // populating its own.
+        Parallel.For(0, 20, i =>
+        {
+            var start = (uint)(i % 10) * CHUNK_SIZE;
+
+            var fileSelection = new HyperslabSelection(
+                start: start,
+                block: CHUNK_SIZE
+            );
+
+            var actual = dataset.Read<int[]>(datasetAccess, fileSelection);
+
+            // Assert
+            var expected = SharedTestData.HugeData.AsSpan((int)start, CHUNK_SIZE).ToArray();
+            Assert.True(actual.SequenceEqual(expected));
+        });
+    }
+
+    /// <summary>
+    /// Variable-length data resolves through the per-file global heap cache, which was a plain
+    /// Dictionary behind a concurrent outer map - so the map that actually held the decoded collections
+    /// was mutated unsynchronized on every miss.
+    /// </summary>
+    [Fact]
+    public void ConcurrentVariableLengthReadsAreCorrect()
+    {
+        // Arrange
+        var version = H5F.libver_t.LATEST;
+
+        var filePath = TestUtils.PrepareTestFile(version, fileId
+            => TestUtils.AddString(fileId, ContainerType.Dataset));
+
+        using var root = NativeFile.InternalOpen(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            deleteOnClose: true);
+
+        var group = root.Group("string");
+        var expected = new string[] { "001", "11", "22", "33", "44", "55", "66", "77", "  ", "AA", "ZZ", "!!" };
+
+        // Act - every reader resolves out of the same global heap collections.
+        Parallel.For(0, 64, _ =>
+        {
+            var actual = group.Dataset("variable").Read<string[]>();
+
+            // Assert
+            Assert.Equal(expected, actual);
+        });
+    }
+}

--- a/tests/PureHDF.Tests/Reading/ChunkCacheTests.cs
+++ b/tests/PureHDF.Tests/Reading/ChunkCacheTests.cs
@@ -4,6 +4,30 @@ namespace PureHDF.Tests.Reading;
 
 public class ChunkCacheTests
 {
+    /// <summary>
+    /// A slot count of zero means "do not cache", and the constructor accepts it - it only rejects a
+    /// negative count. It used to crash on the first chunk instead: with no slots the preemption loop
+    /// ran on an empty map, and FirstOrDefault over an empty sequence yields a default KeyValuePair
+    /// whose Value is null.
+    /// </summary>
+    [Fact]
+    public void ZeroChunkSlotsDisablesTheCacheInsteadOfCrashing()
+    {
+        // Arrange
+        var cache = new SimpleReadingChunkCache(chunkSlotCount: 0);
+        var expected = new byte[] { 1, 2, 3 };
+
+        // Act
+        var first = cache.GetChunk(0, () => expected.AsMemory());
+        var second = cache.GetChunk(0, () => expected.AsMemory());
+
+        // Assert - the chunk is returned, and nothing is retained.
+        Assert.Equal(expected, first.ToArray());
+        Assert.Equal(expected, second.ToArray());
+        Assert.Equal(0, cache.ConsumedSlots);
+        Assert.Equal(0UL, cache.ConsumedBytes);
+    }
+
     [Fact]
     public void CanCacheChunk()
     {

--- a/tests/PureHDF.Tests/Reading/LinkLookupCostTests.cs
+++ b/tests/PureHDF.Tests/Reading/LinkLookupCostTests.cs
@@ -1,0 +1,225 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PureHDF.Tests.Reading;
+
+/// <summary>
+/// Guards that a by-name lookup does not re-decode the object header of the group it is called on.
+/// </summary>
+/// <remarks>
+/// The walk used to begin by dereferencing the group's OWN reference, which builds a second
+/// <c>NativeGroup</c> and decodes that group's object header again from the file. The cost is
+/// proportional to the number of LINKS rather than to the depth of the path, because a group storing
+/// its links compactly holds one header message per link - so a single lookup in a 1000-link group
+/// re-read tens of kilobytes, and a name that did not exist cost exactly as much as one that did.
+/// <para>
+/// Every lookup here uses a DIFFERENT name, deliberately: repeating one name would be served from the
+/// decoded header either way and would look clean even with the defect present.
+/// </para>
+/// <para>
+/// Written with PureHDF's own writer, also deliberately. It emits no b-tree name index, so links are
+/// always stored compactly no matter how many there are - which is both the shape that makes this
+/// expensive and the shape a file produced by this library always has.
+/// </para>
+/// </remarks>
+public class LinkLookupCostTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Counts what the reader actually pulls from the stream, so a lookup's cost can be asserted
+    /// rather than inferred.
+    /// </summary>
+    private sealed class CountingStream(byte[] data) : Stream
+    {
+        private readonly MemoryStream _inner = new(data);
+
+        public long BytesRead { get; private set; }
+
+        public int ReadCount { get; private set; }
+
+        public void ResetCounts()
+        {
+            BytesRead = 0;
+            ReadCount = 0;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _inner.Read(buffer, offset, count);
+
+            BytesRead += read;
+            ReadCount++;
+
+            return read;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var read = _inner.Read(buffer);
+
+            BytesRead += read;
+            ReadCount++;
+
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+        public override void Flush() { }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public void RepeatedLookupsDoNotRedecodeTheGroupHeader()
+    {
+        // Arrange
+        using var stream = new CountingStream(WriteGroupWithManyLinks(1_000));
+        using var root = H5File.Open(stream, leaveOpen: true);
+        var group = root.Group("links");
+
+        // Warm up: decodes the group's object header, including all of its link messages.
+        _ = group.LinkExists("member_0000");
+
+        // Act - 20 distinct names, spread across the group so that no two are adjacent.
+        stream.ResetCounts();
+
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.True(group.LinkExists($"member_{i * 47:D4}"));
+        }
+
+        output.WriteLine($"20 lookups of distinct names: {stream.ReadCount} reads, {stream.BytesRead} bytes");
+
+        // Assert - the header is already held, so resolving a name out of it should read nothing at
+        // all. Asserting zero rather than a bound: there is no structure left to fetch, and a bound
+        // would quietly tolerate the regression coming back at a smaller size.
+        Assert.Equal(0, stream.ReadCount);
+        Assert.Equal(0, stream.BytesRead);
+    }
+
+    /// <summary>
+    /// The cost of a lookup must not grow with the number of links in the group.
+    /// </summary>
+    /// <remarks>
+    /// The scaling check is what identifies this defect specifically, as opposed to any other reason a
+    /// lookup might read: the re-decode was linear in the link count, so doubling the links doubled the
+    /// bytes read. A residual per-lookup cost that is FLAT in the link count would be something else.
+    /// </remarks>
+    [Fact]
+    public void LookupCostDoesNotGrowWithLinkCount()
+    {
+        var measurements = new List<(int Links, long Bytes)>();
+
+        foreach (var linkCount in new[] { 500, 1_000, 2_000 })
+        {
+            using var stream = new CountingStream(WriteGroupWithManyLinks(linkCount));
+            using var root = H5File.Open(stream, leaveOpen: true);
+            var group = root.Group("links");
+
+            _ = group.LinkExists("member_0000");
+
+            stream.ResetCounts();
+            _ = group.LinkExists($"member_{linkCount / 2:D4}");
+
+            measurements.Add((linkCount, stream.BytesRead));
+        }
+
+        foreach (var (links, bytes) in measurements)
+        {
+            output.WriteLine($"{links,5} links: {bytes,8:N0} bytes per lookup");
+        }
+
+        Assert.All(measurements, measurement => Assert.Equal(0, measurement.Bytes));
+    }
+
+    /// <summary>
+    /// The walk must still work for the cases that genuinely need a dereference: a rooted path, and the
+    /// intermediate segments of a nested one.
+    /// </summary>
+    /// <remarks>
+    /// The fix reuses <c>this</c> for the FIRST segment of a relative path only, so these are the paths
+    /// where it must not have broken anything - and the nested case additionally proves the reuse is
+    /// cleared between segments, since keeping it would resolve every segment against the same group
+    /// and find nothing.
+    /// </remarks>
+    [Fact]
+    public void RootedAndNestedPathsStillResolve()
+    {
+        // Arrange
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            var leaf = new H5Group { ["target"] = new H5Dataset(data: 42) };
+            var middle = new H5Group { ["leaf"] = leaf };
+
+            new H5File { ["outer"] = new H5Group { ["middle"] = middle } }.Write(filePath);
+
+            using var root = H5File.OpenRead(filePath);
+
+            // Act + Assert - relative, nested, from the file.
+            Assert.True(root.LinkExists("outer/middle/leaf/target"));
+            Assert.Equal(42, root.Dataset("outer/middle/leaf/target").Read<int>());
+
+            // ... rooted, from the file.
+            Assert.True(root.LinkExists("/outer/middle/leaf/target"));
+
+            // ... relative and rooted, from a group partway down. The rooted lookup must resolve from
+            // the FILE, not from the group it was called on.
+            var outer = root.Group("outer");
+
+            Assert.True(outer.LinkExists("middle/leaf/target"));
+            Assert.True(outer.LinkExists("/outer/middle/leaf/target"));
+            Assert.False(outer.LinkExists("/middle/leaf/target"));
+
+            // A name that does not exist must still report not-found rather than throwing.
+            Assert.False(outer.LinkExists("nope"));
+            Assert.False(root.LinkExists("outer/nope/leaf"));
+
+            // Get takes the same walk and must agree with LinkExists about what resolves.
+            Assert.Throws<Exception>(() => outer.Get("nope"));
+            Assert.NotNull(outer.Get("middle/leaf/target"));
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
+    private static byte[] WriteGroupWithManyLinks(int linkCount)
+    {
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            var links = new H5Group();
+
+            for (int i = 0; i < linkCount; i++)
+            {
+                links[$"member_{i:D4}"] = new H5Group();
+            }
+
+            new H5File { ["links"] = links }.Write(filePath);
+
+            return File.ReadAllBytes(filePath);
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+}

--- a/tests/PureHDF.Tests/Reading/ShortReadTests.cs
+++ b/tests/PureHDF.Tests/Reading/ShortReadTests.cs
@@ -1,0 +1,117 @@
+using Xunit;
+
+namespace PureHDF.Tests.Reading;
+
+/// <summary>
+/// A <see cref="Stream" /> is allowed to return fewer bytes than asked for, and several real ones do:
+/// network streams, pipes and decompressing streams routinely return partial reads. These tests pin
+/// the driver's behaviour when that happens.
+/// </summary>
+public class ShortReadTests
+{
+    /// <summary>
+    /// A stream that never returns more than <paramref name="maxBytesPerRead" /> bytes per call, so a
+    /// caller that ignores the returned count - or reads into the wrong slice of its buffer - is caught.
+    /// </summary>
+    private sealed class ShortReadStream(byte[] data, int maxBytesPerRead) : Stream
+    {
+        private readonly MemoryStream _inner = new(data);
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => _inner.Read(buffer, offset, Math.Min(count, maxBytesPerRead));
+
+        public override int Read(Span<byte> buffer)
+            => _inner.Read(buffer[..Math.Min(buffer.Length, maxBytesPerRead)]);
+
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+        public override void Flush() { }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private static byte[] WriteFile()
+    {
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            var data = Enumerable.Range(0, 10_000).ToArray();
+
+            new H5File
+            {
+                ["group"] = new H5Group
+                {
+                    ["contiguous"] = new H5Dataset(data)
+                }
+            }.Write(filePath);
+
+            return File.ReadAllBytes(filePath);
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
+    /// <summary>
+    /// Dataset payload read through a stream that returns short reads must still be correct.
+    /// </summary>
+    /// <remarks>
+    /// The loop in <c>H5StreamDriver.ReadDataset</c> advanced its <c>remainingBuffer</c> but kept
+    /// passing the ORIGINAL buffer to <c>Read</c>, so every partial read landed at offset zero and
+    /// overwrote the bytes already there while the loop counted them as progress. The result was
+    /// silently wrong data - no exception, no short buffer, just the first few bytes repeated and the
+    /// tail left as zeros. A FileStream normally fills the buffer, which is why this went unnoticed.
+    /// </remarks>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(1024)]
+    public void ContiguousDatasetIsCorrectWhenTheStreamReturnsShortReads(int maxBytesPerRead)
+    {
+        // Arrange
+        var expected = Enumerable.Range(0, 10_000).ToArray();
+
+        using var stream = new ShortReadStream(WriteFile(), maxBytesPerRead);
+        using var root = H5File.Open(stream, leaveOpen: true);
+
+        // Act
+        var actual = root.Group("group").Dataset("contiguous").Read<int[]>();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Structural reads must be correct too: the driver's small fixed-width reads discarded the count
+    /// returned by <c>Stream.Read</c> altogether, so a short read left part of the value as whatever
+    /// the stack slot happened to hold. With a one-byte-per-read stream every multi-byte length,
+    /// address and checksum in the file decodes to garbage.
+    /// </summary>
+    [Fact]
+    public void FileStructureIsReadableWhenTheStreamReturnsOneByteAtATime()
+    {
+        // Arrange
+        using var stream = new ShortReadStream(WriteFile(), maxBytesPerRead: 1);
+
+        // Act
+        using var root = H5File.Open(stream, leaveOpen: true);
+
+        // Assert
+        Assert.True(root.LinkExists("group/contiguous"));
+        Assert.Equal(10_000UL, root.Group("group").Dataset("contiguous").Space.Dimensions[0]);
+    }
+}


### PR DESCRIPTION
Five independent reader fixes, found while building an asynchronous read path on
top of `dev` downstream. They are unrelated to that work and apply on their own,
so they are here separately.

Each one was confirmed to fail against unmodified `dev` before being fixed, and
each commit is self-contained — happy to split this into five PRs if you would
rather review them that way.

## 1. `fix(vfd)`: partial reads in the stream driver

A `Stream` may legally return fewer bytes than asked for, and network streams,
pipes and decompressing streams routinely do. Three places assumed otherwise:

- `H5StreamDriver.ReadDataset` looped over a `remainingBuffer` but kept passing
  the **original** buffer to `Read`, so a partial read restarted at offset zero
  and overwrote bytes it had already delivered while the loop counted them as
  progress. The caller got silently wrong data — a repeated prefix and a
  zero-filled tail, no exception.
- `H5StreamDriver.Read<T>` discarded `Read`'s return value entirely, so a
  partial read left the rest of the value as whatever the stack slot held.
  Every length, address and checksum decodes through here, so against a
  one-byte-at-a-time stream the file does not open at all.
- The pre-net8.0 `ReadExactly` shim treated a zero-byte read as progress, so a
  truncated file spun there forever instead of failing. It now throws
  `EndOfStreamException`, matching `Stream.ReadExactly` on net8.0+.

A `FileStream` normally fills the buffer, which is why none of this shows up in
the existing tests. `ShortReadTests` wraps the file bytes in a stream that caps
every read; all four cases fail before the fix.

## 2. `fix(cache)`: `NativeCache` thread safety

Both caches were `ConcurrentDictionary<H5DriverBase, Dictionary<...>>` — only
the **outer** map was concurrent, while the inner `Dictionary` that actually
held the entries was mutated with no synchronization. So two readers
concurrently reading variable-length data, object references or virtual
datasets through one file raced on a plain `Dictionary`. Nothing else stood in
the way of hitting this: the driver cursor is a `ThreadLocal` and
`ConcurrencyTests` already covers parallel reads.

`AddOrUpdate` was also called with an update lambda returning the newly created
map unconditionally, so when two readers both missed, one reader's map — and
everything decoded into it — was silently dropped. That is only wasted work for
the global heap, but for the external file cache the loser was an open
`NativeFile` that nothing would ever dispose, since `Clear` only disposes what
is in the map.

`ConcurrentVariableLengthReadsAreCorrect` reproduces it. It is a stress test
and detects the race probabilistically — 3 of 8 runs against the unfixed code,
failing with the runtime's own *"Operations that change non-concurrent
collections must have exclusive access … corrupted its state"* — but it cannot
fail once the mutations are synchronized.

## 3. `fix(cache)`: `SimpleReadingChunkCache` under concurrent reads

A caller can share one chunk cache across concurrent reads via
`H5DatasetAccess.ChunkCache`, and `_chunkInfoMap` plus the `ConsumedBytes`
accounting were mutated unsynchronized. The default path never shares a cache —
the default factory builds one per read — so this only bit callers who opted
in, and sharing is the only reason to pass a cache at all.

The lock is deliberately not held across `chunkReader()`; holding it there
would serialize every reader sharing the cache behind one read plus
decompression. Two readers racing on the same chunk therefore both decode it
and one result is discarded — wasted work, never incorrect.

One thing worth recording in case cached chunks are ever pooled: eviction while
another reader is still decoding out of an evicted chunk is safe only because
cached chunks are plain GC-allocated arrays, so eviction drops a reference and
the holder's `Memory` keeps the array alive. Pooling them would break that, and
a lock would no longer be sufficient.

## 4. `fix(cache)`: zero-slot chunk cache crash

`new SimpleReadingChunkCache(chunkSlotCount: 0)` reads as "do not cache" and
the constructor accepts it — it only rejects a negative count. The first chunk
read then threw `NullReferenceException`: with no slots the preemption loop ran
against an empty map, and `FirstOrDefault` over an empty sequence yields a
default `KeyValuePair` whose `Value` is null.

## 5. `perf(reading)`: group header re-decode on by-name lookup

`InternalLinkExists` and `InternalGet` both began by dereferencing the group's
own reference, which builds a second `NativeGroup` and decodes that group's
object header again from the file, discarding the one already held. For a
relative path the first hop *is* that group.

The cost was proportional to the number of **links**, not to path depth,
because a group storing links compactly keeps one header message per link:

| links | bytes read per `LinkExists` |
|------:|----------------------------:|
|   500 |                      15,036 |
| 1,000 |                      30,036 |
| 2,000 |                      60,036 |

Exactly linear, and a name that did not exist cost the same as one that did,
since the whole cost was the re-decode rather than the search. Now zero at
every size.

Only the first segment of a relative path can reuse a group already held; later
segments name unresolved objects, so the reuse is cleared after each pass, and
a rooted path starts at the file and still dereferences.
`LinkLookupCostTests` covers the rooted and nested paths alongside the cost
assertions, and looks up **different** names each time — repeating one name is
served out of the decoded header either way and looks clean even with the
defect present.

## Verification

`dotnet test -f net8.0`: 520 passed, 0 failed, 10 skipped (HSDS and
`CanCopyLikeCLib`, skipped on `dev` as well). Also builds clean for net6.0.

