### PR TITLE
feat(writing): keep file structure together, front-loaded by default

### DIFF
--- a/doc/writing/index.md
+++ b/doc/writing/index.md
@@ -91,11 +91,12 @@ file.Write("path/to/file.h5", options);
 | `Aggregated` | from blocks that double in size, forming a few clusters | needs no estimate of the total; costs a proportion of the metadata, not a fixed block |
 | `FrontLoaded` | from one region reserved at the front | a reader fetches all structure in one range |
 
-Measured over a stream counting what an HTTP range client would transfer, walking a file of 600 groups with deflated datasets at 256 kB ranges (on .NET 8 - a runtime whose deflate packs the same data differently moves the absolute figures, not the ratio):
+Measured over a stream counting what an HTTP range client would transfer, walking a file of 600 groups of deflated measurement series at 256 kB ranges:
 
 ```
-interleaved    fetched 3,666,125 B of 3,666,125 B   100.0% of file   14 requests
-front-loaded   fetched   262,144 B of 3,678,461 B     7.1% of file    1 request
+interleaved    fetched 4,050,543 B of 4,050,543 B   100.0% of file   16 requests
+aggregated     fetched   786,432 B of 4,052,705 B    19.4% of file    3 requests
+front-loaded   fetched   262,144 B of 4,062,879 B     6.5% of file    1 request
 ```
 
 Front loading always ends at a single request, since the reservation is one contiguous span. The interleaved cost is the whole file however large it grows, so the gap widens with size.

--- a/doc/writing/index.md
+++ b/doc/writing/index.md
@@ -88,7 +88,7 @@ file.Write("path/to/file.h5", options);
 | Placement | Allocation | Effect |
 |---|---|---|
 | `Interleaved` | in encode order | the default, and what the writer has always produced |
-| `Aggregated` | from large blocks, forming a few clusters | needs no estimate of the total; costs at most one unused block |
+| `Aggregated` | from blocks that double in size, forming a few clusters | needs no estimate of the total; costs a proportion of the metadata, not a fixed block |
 | `FrontLoaded` | from one region reserved at the front | a reader fetches all structure in one range |
 
 Measured over a stream counting what an HTTP range client would transfer, walking a file of 600 groups with deflated datasets at 256 kB ranges (on .NET 8 - a runtime whose deflate packs the same data differently moves the absolute figures, not the ratio):

--- a/doc/writing/index.md
+++ b/doc/writing/index.md
@@ -99,9 +99,9 @@ aggregated     fetched   786,432 B of 4,052,705 B    19.4% of file    3 requests
 front-loaded   fetched   262,144 B of 4,062,879 B     6.5% of file    1 request
 ```
 
-Front loading always ends at a single request, since the reservation is one contiguous span. The interleaved cost is the whole file however large it grows, so the gap widens with size.
+Front loading ends at a single request whenever the reservation holds all the structure, since it is one contiguous span; a reservation that falls short spills into blocks and costs one request per block. The interleaved cost is the whole file however large it grows, so the gap widens with size.
 
-`FrontLoaded` sizes its reservation by measuring rather than estimating: the writer encodes the file once against a stream that discards everything and reads the total off its allocator. The pass does not compress and, for fixed-size data, does not touch the data at all, so it costs a fraction of the write it precedes. Set `MetadataReservation` to a byte count to skip the pass - and do set it when writing variable-length data through `BeginWrite`, since how much global heap such data needs follows from values the pass has not seen yet.
+`FrontLoaded` sizes its reservation by measuring rather than estimating: the writer encodes the file once against a stream that discards everything and reads the total off its allocator. The pass does not compress and, for fixed-size data, does not touch the data at all, so it costs a fraction of the write it precedes. Because the figure is exact, a front-loaded file is the same size as an interleaved one rather than merely close to it. Set `MetadataReservation` to a byte count to skip the pass; nothing else requires it, including a deferred write through `BeginWrite`, since nothing written later changes how much structure the file has.
 
 A reservation that turns out too small spills into blocks, so it loses locality rather than failing. All three placements produce valid HDF5 - the format imposes no ordering - and the choice costs nothing on read for a local file.
 

--- a/doc/writing/index.md
+++ b/doc/writing/index.md
@@ -70,6 +70,40 @@ file.Write("path/to/file.h5");
 > [!NOTE]
 > Please refer to [data types](data-types.md) for more information about how to write special data types.
 
+## Metadata placement
+
+By default the writer allocates file structure - object headers, chunk indexes, global heap collections - in the order it encodes it, so structure ends up spread evenly through the file alongside the data.
+
+That costs nothing locally, but it is expensive for a reader that fetches ranges rather than seeking freely, typically over HTTP. Such a reader has to see every byte of structure to walk the file, so structure in every range means downloading every range. `H5WriteOptions.MetadataPlacement` offers two alternatives:
+
+```cs
+var options = new H5WriteOptions
+{
+    MetadataPlacement = H5MetadataPlacement.FrontLoaded
+};
+
+file.Write("path/to/file.h5", options);
+```
+
+| Placement | Allocation | Effect |
+|---|---|---|
+| `Interleaved` | in encode order | the default, and what the writer has always produced |
+| `Aggregated` | from large blocks, forming a few clusters | needs no estimate of the total; costs at most one unused block |
+| `FrontLoaded` | from one region reserved at the front | a reader fetches all structure in one range |
+
+Measured over a stream counting what an HTTP range client would transfer, walking a file of 600 groups with deflated datasets at 256 kB ranges (on .NET 8 - a runtime whose deflate packs the same data differently moves the absolute figures, not the ratio):
+
+```
+interleaved    fetched 3,666,125 B of 3,666,125 B   100.0% of file   14 requests
+front-loaded   fetched   262,144 B of 3,678,461 B     7.1% of file    1 request
+```
+
+Front loading always ends at a single request, since the reservation is one contiguous span. The interleaved cost is the whole file however large it grows, so the gap widens with size.
+
+`FrontLoaded` sizes its reservation by measuring rather than estimating: the writer encodes the file once against a stream that discards everything and reads the total off its allocator. The pass does not compress and, for fixed-size data, does not touch the data at all, so it costs a fraction of the write it precedes. Set `MetadataReservation` to a byte count to skip the pass - and do set it when writing variable-length data through `BeginWrite`, since how much global heap such data needs follows from values the pass has not seen yet.
+
+A reservation that turns out too small spills into blocks, so it loses locality rather than failing. All three placements produce valid HDF5 - the format imposes no ordering - and the choice costs nothing on read for a local file.
+
 ## Deferred writing
 
 You may want to write data at a later point in time (for instance if the data is not available yet) and for this scenario PureHDF offers a slightly different API. The following example shows how to use the `H5File.BeginWrite(...)` method to get a writer which allows you to write data to the dataset one or multiple times until the writer instance is being disposed.

--- a/src/PureHDF/API.Writing/H5MetadataPlacement.cs
+++ b/src/PureHDF/API.Writing/H5MetadataPlacement.cs
@@ -35,10 +35,10 @@ public enum H5MetadataPlacement
     /// <para>
     /// Blocks start small and double up to <see cref="H5WriteOptions.MetadataBlockSize" />, so the space
     /// claimed is proportional to the metadata the file turns out to have rather than a floor it pays
-    /// whatever its size. The cost is a handful of clusters rather than one: measured over a range-
-    /// fetching reader on an 18 MB file, walking the structure took 7 requests and 10.0% of the file,
-    /// against 70 requests and all of it under <see cref="Interleaved" />. Prefer
-    /// <see cref="FrontLoaded" /> where the round trips matter - it reached 4 - and this where the sizing
+    /// whatever its size. The cost is a handful of clusters rather than one: measured over a
+    /// range-fetching reader on a 4 MB file of 600 groups, walking the structure took 3 requests and
+    /// 19.4% of the file, against 16 requests and all of it under <see cref="Interleaved" />. Prefer
+    /// <see cref="FrontLoaded" /> where the round trips matter - it took 1 - and this where the sizing
     /// pass is unwelcome.
     /// </para>
     /// </remarks>
@@ -61,9 +61,8 @@ public enum H5MetadataPlacement
     /// reports as unaccounted space. A measured reservation is neither: it is the exact number of bytes
     /// that will be served from it, so a front-loaded file is the same size as an interleaved one rather
     /// than merely close to it, and nothing is abandoned.
-    /// Set <see cref="H5WriteOptions.MetadataReservation" /> when writing variable-length data after the
-    /// initial write through <see cref="H5File.BeginWrite(string, H5WriteOptions?)" />: the global heap
-    /// such data needs is sized from the values, which the measuring pass has not seen.
+    /// A deferred write through <see cref="H5File.BeginWrite(string, H5WriteOptions?)" /> needs no
+    /// allowance for this: nothing a caller writes later changes how much structure the file has.
     /// </para>
     /// <para>
     /// Suited to a file written once and then only read - which is every file this library produces, as

--- a/src/PureHDF/API.Writing/H5MetadataPlacement.cs
+++ b/src/PureHDF/API.Writing/H5MetadataPlacement.cs
@@ -58,8 +58,9 @@ public enum H5MetadataPlacement
     /// <para>
     /// A reservation too small for the file places the remainder as <see cref="Aggregated" /> would, which
     /// loses locality rather than failing. One too large wastes the unused tail, which <c>h5stat</c>
-    /// reports as unaccounted space. A measured reservation is neither, so the only file-size cost is the
-    /// small fixed slack the writer adds to keep the last allocation from spilling.
+    /// reports as unaccounted space. A measured reservation is neither: it is the exact number of bytes
+    /// that will be served from it, so a front-loaded file is the same size as an interleaved one rather
+    /// than merely close to it, and nothing is abandoned.
     /// Set <see cref="H5WriteOptions.MetadataReservation" /> when writing variable-length data after the
     /// initial write through <see cref="H5File.BeginWrite(string, H5WriteOptions?)" />: the global heap
     /// such data needs is sized from the values, which the measuring pass has not seen.

--- a/src/PureHDF/API.Writing/H5MetadataPlacement.cs
+++ b/src/PureHDF/API.Writing/H5MetadataPlacement.cs
@@ -26,12 +26,21 @@ public enum H5MetadataPlacement
     Interleaved = 0,
 
     /// <summary>
-    /// Structure is allocated from large blocks, so it forms a few clusters rather than being spread
-    /// evenly. Needs no estimate of the total, and costs at most one block of file size.
+    /// Structure is allocated from blocks, so it forms a few clusters rather than being spread evenly.
+    /// Needs no estimate of the total.
     /// </summary>
     /// <remarks>
     /// The equivalent of the HDF5 C library's <c>H5Pset_meta_block_size</c>. Use this when the shape of
     /// the file is not known ahead of time.
+    /// <para>
+    /// Blocks start small and double up to <see cref="H5WriteOptions.MetadataBlockSize" />, so the space
+    /// claimed is proportional to the metadata the file turns out to have rather than a floor it pays
+    /// whatever its size. The cost is a handful of clusters rather than one: measured over a range-
+    /// fetching reader on an 18 MB file, walking the structure took 7 requests and 10.0% of the file,
+    /// against 70 requests and all of it under <see cref="Interleaved" />. Prefer
+    /// <see cref="FrontLoaded" /> where the round trips matter - it reached 4 - and this where the sizing
+    /// pass is unwelcome.
+    /// </para>
     /// </remarks>
     Aggregated = 1,
 

--- a/src/PureHDF/API.Writing/H5MetadataPlacement.cs
+++ b/src/PureHDF/API.Writing/H5MetadataPlacement.cs
@@ -1,0 +1,65 @@
+namespace PureHDF;
+
+/// <summary>
+/// Controls where the writer places file structure relative to dataset payload.
+/// </summary>
+/// <remarks>
+/// This matters only to a reader that fetches the file in ranges rather than mapping it - typically over
+/// HTTP. Such a reader must read every byte of structure to walk the file, so structure spread evenly
+/// through the file costs it the entire file. On a 620 MB file whose structure is 8.2% of its bytes,
+/// walking that structure touched 591 of 591 one-megabyte ranges.
+/// <para>
+/// The file is valid HDF5 under every setting - the format imposes no ordering - so this is purely a
+/// layout hint and costs nothing on read for a local file.
+/// </para>
+/// </remarks>
+public enum H5MetadataPlacement
+{
+    /// <summary>
+    /// Structure and payload are allocated in the order they are encoded, so they interleave.
+    /// </summary>
+    /// <remarks>
+    /// The default, and the cheapest placement in both file size and write time - the only one that adds
+    /// nothing at all to a write. It is what the writer has always produced, so its bytes match those of
+    /// a writer without this option.
+    /// </remarks>
+    Interleaved = 0,
+
+    /// <summary>
+    /// Structure is allocated from large blocks, so it forms a few clusters rather than being spread
+    /// evenly. Needs no estimate of the total, and costs at most one block of file size.
+    /// </summary>
+    /// <remarks>
+    /// The equivalent of the HDF5 C library's <c>H5Pset_meta_block_size</c>. Use this when the shape of
+    /// the file is not known ahead of time.
+    /// </remarks>
+    Aggregated = 1,
+
+    /// <summary>
+    /// Structure is allocated from a single region reserved at the front of the file, so a reader can
+    /// fetch all of it in one range.
+    /// </summary>
+    /// <remarks>
+    /// The region is sized from <see cref="H5WriteOptions.MetadataReservation" /> when that is set, and
+    /// otherwise by measuring: the writer encodes the file once against a stream that discards
+    /// everything and reads the total off its allocator. That figure is exact, since it comes from the
+    /// same encoder and the same allocator, which is what lets it cover a chunk index's dependence on
+    /// chunk count and the global heap's 4 kB collection granularity - neither of which an estimate can
+    /// see, and both of which <c>h5stat</c> excludes from its "File metadata" figure.
+    /// <para>
+    /// A reservation too small for the file places the remainder as <see cref="Aggregated" /> would, which
+    /// loses locality rather than failing. One too large wastes the unused tail, which <c>h5stat</c>
+    /// reports as unaccounted space. A measured reservation is neither, so the only file-size cost is the
+    /// small fixed slack the writer adds to keep the last allocation from spilling.
+    /// Set <see cref="H5WriteOptions.MetadataReservation" /> when writing variable-length data after the
+    /// initial write through <see cref="H5File.BeginWrite(string, H5WriteOptions?)" />: the global heap
+    /// such data needs is sized from the values, which the measuring pass has not seen.
+    /// </para>
+    /// <para>
+    /// Suited to a file written once and then only read - which is every file this library produces, as
+    /// the writer cannot add structure to an existing file at all. Prefer <see cref="Aggregated" /> where
+    /// the sizing pass is unwelcome and one range request per cluster is good enough.
+    /// </para>
+    /// </remarks>
+    FrontLoaded = 2
+}

--- a/src/PureHDF/API.Writing/H5WriteOptions.cs
+++ b/src/PureHDF/API.Writing/H5WriteOptions.cs
@@ -34,4 +34,55 @@ public record H5WriteOptions(
     Func<PropertyInfo, string?>? PropertyNameMapper = default,
     Func<PropertyInfo, int?>? PropertyStringLengthMapper = default,
     List<H5Filter>? Filters = default
-);
+)
+{
+    // Declared in the body rather than as further positional parameters, deliberately: adding a
+    // parameter to a record's primary constructor changes its signature, which is a binary-breaking
+    // change for anything compiled against the previous version, while adding a property is not.
+
+    /// <summary>
+    /// Where the writer places file structure relative to dataset payload. The default,
+    /// <see cref="H5MetadataPlacement.Interleaved" />, allocates in encode order and adds nothing to a
+    /// write, which is the layout the writer has always produced.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="H5MetadataPlacement.FrontLoaded" /> to keep structure together at the front of the
+    /// file, which is what a reader fetching ranges over a high-latency link wants. See
+    /// <see cref="H5MetadataPlacement" /> for what each one buys and costs.
+    /// </remarks>
+    public H5MetadataPlacement MetadataPlacement { get; init; } = H5MetadataPlacement.Interleaved;
+
+    /// <summary>
+    /// The size in bytes of a metadata block, used when <see cref="MetadataPlacement" /> is
+    /// <see cref="H5MetadataPlacement.Aggregated" />. The default is 8 MB.
+    /// </summary>
+    /// <remarks>
+    /// Larger blocks cluster more structure together and waste more of the final block. A block smaller
+    /// than the largest single metadata allocation cannot hold it, and such an allocation falls back to
+    /// being placed inline.
+    /// </remarks>
+    public long MetadataBlockSize { get; init; } = 8 * 1024 * 1024;
+
+    /// <summary>
+    /// The size in bytes reserved at the front of the file for structure, used when
+    /// <see cref="MetadataPlacement" /> is <see cref="H5MetadataPlacement.FrontLoaded" />. Zero, the
+    /// default, means the writer measures it.
+    /// </summary>
+    /// <remarks>
+    /// Measuring means encoding the file once against a stream that discards everything, which yields an
+    /// exact figure rather than an estimate because it is the same encoder and allocator. It does not
+    /// compress, so on a filtered write it adds a low single-digit percentage; on an unfiltered write the
+    /// share is larger, but an unfiltered write is cheap to begin with.
+    /// <para>
+    /// Set an explicit value to skip that pass. Doing so also covers the one case a measurement cannot
+    /// reach: variable-length data written through
+    /// <see cref="H5File.BeginWrite(string, H5WriteOptions?)" /> after the initial write. Such data goes
+    /// on the global heap, and how much heap it needs follows from the values themselves, which the
+    /// measuring pass has not seen. Everything else about a deferred dataset is already covered, since a
+    /// chunk index is sized from the chunk count, which comes from the dimensions rather than from the
+    /// data. A reservation that falls short spills into blocks, so the effect is a loss of locality for
+    /// the remainder rather than a failure.
+    /// </para>
+    /// </remarks>
+    public long MetadataReservation { get; init; }
+}

--- a/src/PureHDF/API.Writing/H5WriteOptions.cs
+++ b/src/PureHDF/API.Writing/H5WriteOptions.cs
@@ -62,6 +62,10 @@ public record H5WriteOptions(
     /// value, so what a file pays is proportional to the metadata it has rather than a floor it pays
     /// whatever its size. Raising this clusters more structure per block once a file is large enough to
     /// reach it. An allocation larger than this cannot be held by a block at all, and is placed inline.
+    /// <para>
+    /// Must be greater than zero for any placement other than
+    /// <see cref="H5MetadataPlacement.Interleaved" />, which uses no blocks and ignores it.
+    /// </para>
     /// </remarks>
     public long MetadataBlockSize { get; init; } = 8 * 1024 * 1024;
 

--- a/src/PureHDF/API.Writing/H5WriteOptions.cs
+++ b/src/PureHDF/API.Writing/H5WriteOptions.cs
@@ -53,13 +53,15 @@ public record H5WriteOptions(
     public H5MetadataPlacement MetadataPlacement { get; init; } = H5MetadataPlacement.Interleaved;
 
     /// <summary>
-    /// The size in bytes of a metadata block, used when <see cref="MetadataPlacement" /> is
-    /// <see cref="H5MetadataPlacement.Aggregated" />. The default is 8 MB.
+    /// The largest metadata block the writer will open, in bytes. The default is 8 MB. It applies when
+    /// <see cref="MetadataPlacement" /> is <see cref="H5MetadataPlacement.Aggregated" />, and to the
+    /// remainder when a <see cref="H5MetadataPlacement.FrontLoaded" /> reservation runs out.
     /// </summary>
     /// <remarks>
-    /// Larger blocks cluster more structure together and waste more of the final block. A block smaller
-    /// than the largest single metadata allocation cannot hold it, and such an allocation falls back to
-    /// being placed inline.
+    /// A ceiling rather than a fixed size: the first block is small and each one doubles up to this
+    /// value, so what a file pays is proportional to the metadata it has rather than a floor it pays
+    /// whatever its size. Raising this clusters more structure per block once a file is large enough to
+    /// reach it. An allocation larger than this cannot be held by a block at all, and is placed inline.
     /// </remarks>
     public long MetadataBlockSize { get; init; } = 8 * 1024 * 1024;
 

--- a/src/PureHDF/API.Writing/H5WriteOptions.cs
+++ b/src/PureHDF/API.Writing/H5WriteOptions.cs
@@ -76,14 +76,14 @@ public record H5WriteOptions(
     /// compress, so on a filtered write it adds a low single-digit percentage; on an unfiltered write the
     /// share is larger, but an unfiltered write is cheap to begin with.
     /// <para>
-    /// Set an explicit value to skip that pass. Doing so also covers the one case a measurement cannot
-    /// reach: variable-length data written through
-    /// <see cref="H5File.BeginWrite(string, H5WriteOptions?)" /> after the initial write. Such data goes
-    /// on the global heap, and how much heap it needs follows from the values themselves, which the
-    /// measuring pass has not seen. Everything else about a deferred dataset is already covered, since a
-    /// chunk index is sized from the chunk count, which comes from the dimensions rather than from the
-    /// data. A reservation that falls short spills into blocks, so the effect is a loss of locality for
-    /// the remainder rather than a failure.
+    /// Set an explicit value only to skip that pass. It buys nothing else: a measured reservation is the
+    /// exact number of bytes that will be served from it, so it abandons nothing, while an explicit one
+    /// abandons whatever it over-reserved. Data written later through
+    /// <see cref="H5File.BeginWrite(string, H5WriteOptions?)" /> needs no allowance either - a chunk
+    /// index is sized from the chunk count, which comes from the dimensions rather than from the data,
+    /// and a variable-length value's heap space is payload rather than structure, so writing more of it
+    /// does not move the total. A reservation that nonetheless falls short spills into blocks, which
+    /// loses locality for the remainder rather than failing.
     /// </para>
     /// </remarks>
     public long MetadataReservation { get; init; }

--- a/src/PureHDF/VOL/Native/API.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/API.Writing/H5NativeWriter.cs
@@ -65,6 +65,26 @@ public partial class H5NativeWriter : IDisposable
                 Context.GlobalHeapManager.Encode();
 
                 // superblock
+                //
+                // The end-of-file address must cover everything ALLOCATED, not merely everything
+                // written, because an address can be referenced without ever being written to: a
+                // dataset created through BeginWrite has its payload allocated and named by its layout
+                // message whether or not the caller ever writes it. Nothing extends the stream over
+                // that payload, and a placement decides whether anything else does - an interleaved
+                // file usually has metadata allocated after it, whose writes extend the stream by
+                // accident, while a front-loaded one serves metadata from the front and leaves the
+                // stream ending before the payload the layout points at. h5dump then rejects the
+                // dataset outright: "invalid dataset size, likely file corruption".
+                //
+                // So the stream is extended to the allocator's mark rather than the address being
+                // trimmed to the stream. Trimming would be smaller - an abandoned region tail is
+                // usually the last thing in the file, and it is referenced by nothing - but it cannot
+                // be told apart from the payload case here, and getting it wrong truncates data.
+                var highWaterMark = Context.FreeSpaceManager.HighWaterMark;
+
+                if (Context.Driver.Length < highWaterMark)
+                    Context.Driver.SetLength(highWaterMark);
+
                 var endOfFileAddress = (ulong)Context.Driver.Length;
 
                 var superblock = new Superblock23(

--- a/src/PureHDF/VOL/Native/API.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/API.Writing/H5NativeWriter.cs
@@ -80,7 +80,11 @@ public partial class H5NativeWriter : IDisposable
                 // trimmed to the stream. Trimming would be smaller - an abandoned region tail is
                 // usually the last thing in the file, and it is referenced by nothing - but it cannot
                 // be told apart from the payload case here, and getting it wrong truncates data.
-                var highWaterMark = Context.FreeSpaceManager.HighWaterMark;
+                // BaseAddress is added because the allocator counts from the superblock while the
+                // driver's Length and SetLength count from the start of the file, and a user block puts
+                // those a UserBlockSize apart. Comparing them untranslated makes the guard read as
+                // already-long-enough and skip an extension the file needs.
+                var highWaterMark = (long)Context.Driver.BaseAddress + Context.FreeSpaceManager.HighWaterMark;
 
                 if (Context.Driver.Length < highWaterMark)
                     Context.Driver.SetLength(highWaterMark);

--- a/src/PureHDF/VOL/Native/API.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/API.Writing/H5NativeWriter.cs
@@ -1,4 +1,5 @@
 using PureHDF.Selections;
+using PureHDF.VOL.Native;
 
 namespace PureHDF;
 
@@ -29,14 +30,27 @@ public partial class H5NativeWriter : IDisposable
         // TODO cache this
         var method = _methodInfoWriteDataset.MakeGenericMethod(dataset.Type, elementType);
 
-        method.Invoke(this,
-        [
-            info.H5D,
-            info.Encode,
-            data,
-            memorySelection,
-            fileSelection
-        ]);
+        // As in InternalEncodeDataset: variable-length elements written here are the dataset's payload,
+        // so their heap collections are allocated as payload too.
+        var enclosing = Context.GlobalHeapManager.AllocationKind;
+        Context.GlobalHeapManager.AllocationKind = AllocationKind.RawData;
+
+        try
+        {
+            method.Invoke(this,
+            [
+                info.H5D,
+                info.Encode,
+                data,
+                memorySelection,
+                fileSelection
+            ]);
+        }
+
+        finally
+        {
+            Context.GlobalHeapManager.AllocationKind = enclosing;
+        }
     }
 
     /// <summary>

--- a/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
@@ -1,18 +1,165 @@
-﻿namespace PureHDF.VOL.Native;
+namespace PureHDF.VOL.Native;
+
+/// <summary>
+/// What an allocation holds, which is what lets the allocator keep structure and payload apart.
+/// </summary>
+/// <remarks>
+/// The distinction is the reader's, not the writer's: a range-request reader walking a file's structure
+/// needs every byte of metadata and none of the raw data, so metadata scattered through the file costs
+/// it the whole file. See <see cref="H5MetadataPlacement" />.
+/// </remarks>
+internal enum AllocationKind
+{
+    /// <summary>
+    /// File structure: the superblock, object headers, chunk indexes and their data blocks, and global
+    /// heap collections. Global heap counts as metadata because it holds attribute payload, which is
+    /// what a viewer reads while browsing rather than while reading a dataset.
+    /// </summary>
+    Metadata,
+
+    /// <summary>
+    /// Dataset payload: contiguous data and chunk data.
+    /// </summary>
+    RawData
+}
 
 internal class FreeSpaceManager
 {
+    private readonly H5MetadataPlacement _placement;
+    private readonly long _blockSize;
+
     private long _length;
 
-    public long Allocate(long length)
+    // The metadata region currently being filled: [_metadataCursor, _metadataRegionEnd). Empty when
+    // the two are equal, which is always the case for H5MetadataPlacement.Interleaved.
+    private long _metadataCursor;
+    private long _metadataRegionEnd;
+
+    public FreeSpaceManager(H5MetadataPlacement placement = H5MetadataPlacement.Interleaved, long blockSize = 0)
+    {
+        _placement = placement;
+        _blockSize = blockSize;
+    }
+
+    /// <summary>
+    /// The first byte past everything allocated so far.
+    /// </summary>
+    /// <remarks>
+    /// Not the same as the stream length once a metadata region is in play: the tail of a region that
+    /// nothing was written into is allocated but never touched, so the stream can be shorter than this.
+    /// The end-of-file address in the superblock must cover it regardless, or a reader is entitled to
+    /// treat addresses beyond the declared end as invalid.
+    /// </remarks>
+    public long HighWaterMark => _length;
+
+    /// <summary>
+    /// Total bytes handed out for <see cref="AllocationKind.Metadata" />.
+    /// </summary>
+    /// <remarks>
+    /// This is what a sizing pass reads off to decide how much to reserve, and why it is a count of
+    /// ALLOCATIONS rather than of encoded bytes: a global heap collection is allocated at a 4 kB minimum
+    /// and usually left partly empty, so the space that has to be reserved exceeds the space that ends up
+    /// meaning anything. h5stat reports that difference as unaccounted space rather than as metadata,
+    /// which is what makes its "File metadata" figure too small to reserve against.
+    /// </remarks>
+    public long MetadataAllocated { get; private set; }
+
+    /// <summary>
+    /// How many metadata regions were opened, and how much of them was abandoned unused. More than one
+    /// region under <see cref="H5MetadataPlacement.FrontLoaded" /> means the reservation was too small
+    /// and the remainder spilled.
+    /// </summary>
+    public int MetadataRegionsOpened { get; private set; }
+
+    public long MetadataAbandoned { get; private set; }
+
+    /// <summary>
+    /// Allocates metadata at the current end of the file, bypassing regions and blocks entirely.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the superblock, which must land at offset zero. It cannot go through
+    /// <see cref="Allocate" />: with blocks enabled the first metadata request opens a block, so routing
+    /// the superblock there gives it a whole block to itself, ahead of the region - which costs that
+    /// block of file size and pushes the region away from the front, the one thing the front-loaded
+    /// placement exists to avoid.
+    /// </remarks>
+    public long AllocateAtFront(long length)
+    {
+        MetadataAllocated += length;
+
+        var address = _length;
+        _length += length;
+
+        return address;
+    }
+
+    /// <summary>
+    /// Reserves <paramref name="size" /> bytes at the current end of the file for metadata.
+    /// </summary>
+    /// <remarks>
+    /// Called once, immediately after the superblock is allocated, so the region begins as close to the
+    /// front of the file as it can. Metadata is served from here until it is exhausted; raw data is
+    /// always served past the end of the file, so it never lands inside the region.
+    /// </remarks>
+    public void ReserveMetadataRegion(long size)
+    {
+        if (size <= 0)
+            return;
+
+        _metadataCursor = _length;
+        _metadataRegionEnd = _length + size;
+        _length = _metadataRegionEnd;
+        MetadataRegionsOpened++;
+    }
+
+    public long Allocate(long length, AllocationKind kind)
     {
         if (length == 0)
             return Superblock.LongUndefinedAddress;
 
-        var address = _length;
+        if (kind == AllocationKind.Metadata)
+        {
+            MetadataAllocated += length;
 
+            // Serve from the open region while it has room.
+            if (_metadataCursor + length <= _metadataRegionEnd)
+            {
+                var reserved = _metadataCursor;
+                _metadataCursor += length;
+
+                return reserved;
+            }
+
+            // The region is exhausted (or was never opened). Opening a fresh one clusters what follows
+            // instead of scattering it. FrontLoaded does this too rather than failing: an estimate that
+            // came out short degrades to Aggregated behaviour for the remainder, which is worse for
+            // locality but still correct and still far better than interleaving.
+            //
+            // Whatever is left of the old region is abandoned - there is no free list to return it to -
+            // so this trades a bounded amount of file size for locality. The waste is at most one
+            // request's worth per region, since a region is only replaced when the request does not
+            // fit, plus the unused tail of the final region.
+            if (_blockSize > 0 && length <= _blockSize)
+            {
+                MetadataAbandoned += _metadataRegionEnd - _metadataCursor;
+                MetadataRegionsOpened++;
+
+                _metadataCursor = _length;
+                _metadataRegionEnd = _length + _blockSize;
+                _length = _metadataRegionEnd;
+
+                var address = _metadataCursor;
+                _metadataCursor += length;
+
+                return address;
+            }
+        }
+
+        // Raw data, metadata too large to fit a block, and everything at all when the placement is
+        // Interleaved: straight bump allocation at the end of the file, with no region or block involved.
+        var bumped = _length;
         _length += length;
 
-        return address;
+        return bumped;
     }
 }

--- a/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
@@ -42,6 +42,7 @@ internal class FreeSpaceManager
 
     private long _length;
     private long _nextBlockSize;
+    private long _abandonedByReplacement;
 
     // The metadata region currently being filled: [_metadataCursor, _metadataRegionEnd). Empty when
     // the two are equal, which is always the case for H5MetadataPlacement.Interleaved.
@@ -79,13 +80,27 @@ internal class FreeSpaceManager
     public long MetadataAllocated { get; private set; }
 
     /// <summary>
-    /// How many metadata regions were opened, and how much of them was abandoned unused. More than one
-    /// region under <see cref="H5MetadataPlacement.FrontLoaded" /> means the reservation was too small
-    /// and the remainder spilled.
+    /// How many metadata regions were opened. More than one under
+    /// <see cref="H5MetadataPlacement.FrontLoaded" /> means the reservation was too small and the
+    /// remainder spilled.
     /// </summary>
     public int MetadataRegionsOpened { get; private set; }
 
-    public long MetadataAbandoned { get; private set; }
+    /// <summary>
+    /// How much of those regions was claimed and never used.
+    /// </summary>
+    /// <remarks>
+    /// Includes the tail of the region still open, which is the whole point: that tail is the largest
+    /// part of the waste on a file that opened one region and half filled it, and counting only regions
+    /// already replaced reported 48 bytes where 8 MB had been claimed. A region is replaced only when a
+    /// request does not fit, so the remainders that get counted on replacement are small by
+    /// construction, and the one that does not is not.
+    /// <para>
+    /// Live rather than final while a write is in progress: it answers what would be abandoned if the
+    /// write ended now, and the open region's tail shrinks as allocations are served from it.
+    /// </para>
+    /// </remarks>
+    public long MetadataAbandoned => _abandonedByReplacement + (_metadataRegionEnd - _metadataCursor);
 
     /// <summary>
     /// Allocates metadata at the current end of the file, bypassing regions and blocks entirely.
@@ -159,7 +174,7 @@ internal class FreeSpaceManager
                 // request would be abandoned immediately and the request placed inline.
                 var openedSize = Math.Max(_nextBlockSize, length);
 
-                MetadataAbandoned += _metadataRegionEnd - _metadataCursor;
+                _abandonedByReplacement += _metadataRegionEnd - _metadataCursor;
                 MetadataRegionsOpened++;
 
                 _metadataCursor = _length;

--- a/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
@@ -11,15 +11,21 @@ namespace PureHDF.VOL.Native;
 internal enum AllocationKind
 {
     /// <summary>
-    /// File structure: the superblock, object headers, chunk indexes and their data blocks, and global
-    /// heap collections. Global heap counts as metadata because it holds attribute payload, which is
-    /// what a viewer reads while browsing rather than while reading a dataset.
+    /// File structure: the superblock, object headers, chunk indexes and their data blocks, and the
+    /// global heap collections holding attribute values - which a viewer reads while browsing a file,
+    /// rather than while reading a dataset.
     /// </summary>
     Metadata,
 
     /// <summary>
-    /// Dataset payload: contiguous data and chunk data.
+    /// Dataset payload: contiguous data, chunk data, and the global heap collections holding a dataset's
+    /// own variable-length elements.
     /// </summary>
+    /// <remarks>
+    /// The global heap serves both kinds, which is why <see cref="GlobalHeapManager.AllocationKind" />
+    /// exists. Counting all of it as structure put 97% of a variable-length string dataset in the
+    /// metadata region and left a placement nothing to separate.
+    /// </remarks>
     RawData
 }
 

--- a/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
@@ -25,10 +25,23 @@ internal enum AllocationKind
 
 internal class FreeSpaceManager
 {
+    /// <summary>
+    /// The size of the first metadata block. Blocks double from here up to the configured maximum.
+    /// </summary>
+    /// <remarks>
+    /// A block is claimed in full, so a fixed size is paid in full however little metadata the file
+    /// turns out to have: at the 8 MB default, 33 kB of metadata produced an 8.4 MB file. Doubling
+    /// instead bounds the total claimed at roughly twice what is used, which is a proportional cost
+    /// rather than a floor, while a file with enough metadata still reaches the maximum after a handful
+    /// of blocks and clusters as before.
+    /// </remarks>
+    private const long INITIAL_BLOCK_SIZE = 64 * 1024;
+
     private readonly H5MetadataPlacement _placement;
     private readonly long _blockSize;
 
     private long _length;
+    private long _nextBlockSize;
 
     // The metadata region currently being filled: [_metadataCursor, _metadataRegionEnd). Empty when
     // the two are equal, which is always the case for H5MetadataPlacement.Interleaved.
@@ -39,6 +52,7 @@ internal class FreeSpaceManager
     {
         _placement = placement;
         _blockSize = blockSize;
+        _nextBlockSize = Math.Min(INITIAL_BLOCK_SIZE, blockSize);
     }
 
     /// <summary>
@@ -141,12 +155,17 @@ internal class FreeSpaceManager
             // fit, plus the unused tail of the final region.
             if (_blockSize > 0 && length <= _blockSize)
             {
+                // Big enough for the request that opened it, since a block too small to serve that
+                // request would be abandoned immediately and the request placed inline.
+                var openedSize = Math.Max(_nextBlockSize, length);
+
                 MetadataAbandoned += _metadataRegionEnd - _metadataCursor;
                 MetadataRegionsOpened++;
 
                 _metadataCursor = _length;
-                _metadataRegionEnd = _length + _blockSize;
+                _metadataRegionEnd = _length + openedSize;
                 _length = _metadataRegionEnd;
+                _nextBlockSize = Math.Min(openedSize * 2, _blockSize);
 
                 var address = _metadataCursor;
                 _metadataCursor += length;

--- a/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/FreeSpaceManager.cs
@@ -18,15 +18,28 @@ internal enum AllocationKind
     Metadata,
 
     /// <summary>
-    /// Dataset payload: contiguous data, chunk data, and the global heap collections holding a dataset's
-    /// own variable-length elements.
+    /// Dataset payload written at the address it was allocated: contiguous data and chunk data.
+    /// </summary>
+    RawData,
+
+    /// <summary>
+    /// Dataset payload allocated now and written later - the global heap collections holding a dataset's
+    /// own variable-length elements, which are filled progressively and flushed in batches.
     /// </summary>
     /// <remarks>
-    /// The global heap serves both kinds, which is why <see cref="GlobalHeapManager.AllocationKind" />
-    /// exists. Counting all of it as structure put 97% of a variable-length string dataset in the
-    /// metadata region and left a placement nothing to separate.
+    /// Payload, so it stays out of the metadata region: counting it as structure put 97% of a
+    /// variable-length string dataset there and left a placement nothing to separate. But clustered
+    /// rather than bump-allocated, because the gap between allocating and writing is what costs a
+    /// streaming writer. A writer uploading to object storage buffers the file in fixed parts and can
+    /// only ship a part once every byte in it is written, so a region allocated now and written much
+    /// later is a hole that pins its part. Scattered through the file, those holes pin every part and
+    /// the whole object stays in memory; gathered into a few blocks, they pin a few.
+    /// <para>
+    /// Chunk and contiguous payload needs none of this - it is written at the address it was allocated,
+    /// so it leaves no hole behind.
+    /// </para>
     /// </remarks>
-    RawData
+    DeferredRawData
 }
 
 internal class FreeSpaceManager
@@ -47,19 +60,29 @@ internal class FreeSpaceManager
     private readonly long _blockSize;
 
     private long _length;
-    private long _nextBlockSize;
     private long _abandonedByReplacement;
+    private long _payloadAbandonedByReplacement;
 
-    // The metadata region currently being filled: [_metadataCursor, _metadataRegionEnd). Empty when
-    // the two are equal, which is always the case for H5MetadataPlacement.Interleaved.
-    private long _metadataCursor;
-    private long _metadataRegionEnd;
+    // The region currently being filled for each kind that gets one: [Cursor, End). Empty when the two
+    // are equal, which is always the case for H5MetadataPlacement.Interleaved. Metadata and deferred
+    // payload are clustered independently - they must not share a block, or payload would land inside
+    // the region a reader fetches to walk the structure.
+    private Region _metadata;
+    private Region _deferredRawData;
 
     public FreeSpaceManager(H5MetadataPlacement placement = H5MetadataPlacement.Interleaved, long blockSize = 0)
     {
         _placement = placement;
         _blockSize = blockSize;
-        _nextBlockSize = Math.Min(INITIAL_BLOCK_SIZE, blockSize);
+        _metadata = new Region { NextBlockSize = Math.Min(INITIAL_BLOCK_SIZE, blockSize) };
+        _deferredRawData = new Region { NextBlockSize = Math.Min(INITIAL_BLOCK_SIZE, blockSize) };
+    }
+
+    private struct Region
+    {
+        public long Cursor;
+        public long End;
+        public long NextBlockSize;
     }
 
     /// <summary>
@@ -106,7 +129,18 @@ internal class FreeSpaceManager
     /// write ended now, and the open region's tail shrinks as allocations are served from it.
     /// </para>
     /// </remarks>
-    public long MetadataAbandoned => _abandonedByReplacement + (_metadataRegionEnd - _metadataCursor);
+    public long MetadataAbandoned => _abandonedByReplacement + (_metadata.End - _metadata.Cursor);
+
+    /// <summary>
+    /// The same, for the blocks holding <see cref="AllocationKind.DeferredRawData" />.
+    /// </summary>
+    /// <remarks>
+    /// Reported separately because it is payload: it is not what a reservation should be sized against,
+    /// and it is not what <see cref="MetadataRegionsOpened" /> counts. Together with
+    /// <see cref="MetadataAbandoned" /> it accounts for every byte a clustered file carries that an
+    /// interleaved one does not.
+    /// </remarks>
+    public long PayloadAbandoned => _payloadAbandonedByReplacement + (_deferredRawData.End - _deferredRawData.Cursor);
 
     /// <summary>
     /// Allocates metadata at the current end of the file, bypassing regions and blocks entirely.
@@ -141,9 +175,9 @@ internal class FreeSpaceManager
         if (size <= 0)
             return;
 
-        _metadataCursor = _length;
-        _metadataRegionEnd = _length + size;
-        _length = _metadataRegionEnd;
+        _metadata.Cursor = _length;
+        _metadata.End = _length + size;
+        _length = _metadata.End;
         MetadataRegionsOpened++;
     }
 
@@ -156,50 +190,88 @@ internal class FreeSpaceManager
         {
             MetadataAllocated += length;
 
-            // Serve from the open region while it has room.
-            if (_metadataCursor + length <= _metadataRegionEnd)
+            if (TryServeClustered(ref _metadata, length, out var metadataAddress, out var abandoned))
             {
-                var reserved = _metadataCursor;
-                _metadataCursor += length;
+                if (abandoned >= 0)
+                {
+                    _abandonedByReplacement += abandoned;
+                    MetadataRegionsOpened++;
+                }
 
-                return reserved;
-            }
-
-            // The region is exhausted (or was never opened). Opening a fresh one clusters what follows
-            // instead of scattering it. FrontLoaded does this too rather than failing: an estimate that
-            // came out short degrades to Aggregated behaviour for the remainder, which is worse for
-            // locality but still correct and still far better than interleaving.
-            //
-            // Whatever is left of the old region is abandoned - there is no free list to return it to -
-            // so this trades a bounded amount of file size for locality. The waste is at most one
-            // request's worth per region, since a region is only replaced when the request does not
-            // fit, plus the unused tail of the final region.
-            if (_blockSize > 0 && length <= _blockSize)
-            {
-                // Big enough for the request that opened it, since a block too small to serve that
-                // request would be abandoned immediately and the request placed inline.
-                var openedSize = Math.Max(_nextBlockSize, length);
-
-                _abandonedByReplacement += _metadataRegionEnd - _metadataCursor;
-                MetadataRegionsOpened++;
-
-                _metadataCursor = _length;
-                _metadataRegionEnd = _length + openedSize;
-                _length = _metadataRegionEnd;
-                _nextBlockSize = Math.Min(openedSize * 2, _blockSize);
-
-                var address = _metadataCursor;
-                _metadataCursor += length;
-
-                return address;
+                return metadataAddress;
             }
         }
 
-        // Raw data, metadata too large to fit a block, and everything at all when the placement is
-        // Interleaved: straight bump allocation at the end of the file, with no region or block involved.
+        // Payload that is written long after it is allocated, so it is gathered rather than scattered -
+        // see AllocationKind.DeferredRawData. Its own blocks, never the metadata region: a reader
+        // walking the structure must not have to fetch this.
+        else if (kind == AllocationKind.DeferredRawData)
+        {
+            // Counted apart from the structure region's figures, which is what PayloadAbandoned is for.
+            if (TryServeClustered(ref _deferredRawData, length, out var deferredAddress, out var payloadAbandoned))
+            {
+                if (payloadAbandoned >= 0)
+                    _payloadAbandonedByReplacement += payloadAbandoned;
+
+                return deferredAddress;
+            }
+        }
+
         var bumped = _length;
         _length += length;
 
         return bumped;
+    }
+
+    /// <summary>
+    /// Serves <paramref name="length" /> from <paramref name="region" />, opening a fresh block when the
+    /// current one is exhausted. False when blocks are disabled or the request is too large for one, in
+    /// which case the caller bump-allocates instead.
+    /// </summary>
+    /// <remarks>
+    /// Whatever is left of a replaced region is abandoned - there is no free list to return it to - so
+    /// this trades a bounded amount of file size for locality. The waste is at most one request's worth
+    /// per region, since a region is only replaced when the request does not fit, plus the unused tail
+    /// of the final region.
+    /// </remarks>
+    private bool TryServeClustered(ref Region region, long length, out long address, out long abandoned)
+    {
+        // Serve from the open region while it has room.
+        if (region.Cursor + length <= region.End)
+        {
+            address = region.Cursor;
+            region.Cursor += length;
+            abandoned = -1;
+
+            return true;
+        }
+
+        // Exhausted, or never opened. Opening a fresh one clusters what follows instead of scattering
+        // it. FrontLoaded does this too rather than failing: a reservation that came out short degrades
+        // to Aggregated behaviour for the remainder, which is worse for locality but still correct and
+        // still far better than interleaving.
+        if (_blockSize > 0 && length <= _blockSize)
+        {
+            // Big enough for the request that opened it, since a block too small to serve that request
+            // would be abandoned immediately and the request placed inline.
+            var openedSize = Math.Max(region.NextBlockSize, length);
+
+            abandoned = region.End - region.Cursor;
+
+            region.Cursor = _length;
+            region.End = _length + openedSize;
+            _length = region.End;
+            region.NextBlockSize = Math.Min(openedSize * 2, _blockSize);
+
+            address = region.Cursor;
+            region.Cursor += length;
+
+            return true;
+        }
+
+        address = default;
+        abandoned = -1;
+
+        return false;
     }
 }

--- a/src/PureHDF/VOL/Native/Core.Writing/GlobalHeapManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/GlobalHeapManager.cs
@@ -109,7 +109,7 @@ internal class GlobalHeapManager
             CollectionSize = (ulong)collectionSize
         };
 
-        _baseAddress = _freeSpaceManager.Allocate(collectionSize);
+        _baseAddress = _freeSpaceManager.Allocate(collectionSize, AllocationKind.Metadata);
         _memory = new byte[collectionSize - COLLECTION_HEADER_SIZE];
 
         //

--- a/src/PureHDF/VOL/Native/Core.Writing/GlobalHeapManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/GlobalHeapManager.cs
@@ -140,7 +140,13 @@ internal class GlobalHeapManager
             CollectionSize = (ulong)collectionSize
         };
 
-        var baseAddress = _freeSpaceManager.Allocate(collectionSize, kind);
+        // A collection is always allocated now and written later - filled progressively, flushed in
+        // batches - so a payload collection is clustered rather than bump-allocated. See
+        // AllocationKind.DeferredRawData: the gap between allocating and writing is what pins a
+        // streaming writer's buffers, and scattering these holes through the file pins all of them.
+        var baseAddress = _freeSpaceManager.Allocate(
+            collectionSize,
+            kind == AllocationKind.Metadata ? AllocationKind.Metadata : AllocationKind.DeferredRawData);
 
         var collectionState = new GlobalHeapCollectionState(
             Collection: collection,

--- a/src/PureHDF/VOL/Native/Core.Writing/GlobalHeapManager.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/GlobalHeapManager.cs
@@ -11,13 +11,9 @@ internal class GlobalHeapManager
 
     private readonly FreeSpaceManager _freeSpaceManager;
     private readonly Dictionary<long, GlobalHeapCollectionState> _collectionMap = new();
+    private readonly Dictionary<AllocationKind, GlobalHeapCollectionState> _openCollections = new();
     private readonly H5DriverBase _driver;
     private readonly H5WriteOptions _options;
-
-    private GlobalHeapCollectionState? _collectionState;
-    private long _baseAddress;
-    private ushort _index;
-    private Memory<byte> _memory;
 
     public GlobalHeapManager(H5WriteOptions options, FreeSpaceManager freeSpaceManager, H5DriverBase driver)
     {
@@ -29,49 +25,80 @@ internal class GlobalHeapManager
         _driver = driver;
     }
 
+    /// <summary>
+    /// What the collections opened from here hold, and therefore where they are allocated.
+    /// </summary>
+    /// <remarks>
+    /// A global heap collection is metadata when it holds attribute values, which a viewer reads while
+    /// browsing a file, and raw data when it holds a dataset's own variable-length elements, which it
+    /// reads only when reading that dataset. Both go through this one manager, so without the
+    /// distinction a dataset of variable-length strings has its entire payload allocated as structure -
+    /// measured at 97% of such a file - and a placement that segregates structure from payload has
+    /// nothing left to segregate.
+    /// <para>
+    /// Set around an encode rather than passed in, because the delegates that call
+    /// <see cref="AddObject" /> are built by <c>DatatypeMessage.Create</c>, which is shared by both
+    /// paths and cannot tell them apart. The writer scopes it at the two points where it can: a
+    /// dataset's data write, and an attribute's encode. Both restore it, so nesting - an object
+    /// reference inside dataset data encodes the group it points at, attributes and all - stays
+    /// correctly attributed.
+    /// </para>
+    /// <para>
+    /// A collection is kept open per kind, so the two never share one. That is what makes the
+    /// classification meaningful: a collection is allocated whole, so one shared collection would put
+    /// both kinds at whichever address the first object claimed.
+    /// </para>
+    /// </remarks>
+    public AllocationKind AllocationKind { get; set; } = AllocationKind.Metadata;
+
     public (WritingGlobalHeapId, Memory<byte>) AddObject(int objectSize)
     {
         // validation
-        var collectionState = _collectionState;
+        var kind = AllocationKind;
+
+        _openCollections.TryGetValue(kind, out var collectionState);
 
         if (collectionState is null ||
             collectionState.Consumed + OBJECT_HEADER_SIZE + AlignSize(objectSize) > collectionState.Memory.Length)
         {
             collectionState = AddNewCollection(
+                kind,
                 collectionSize: Math.Max(
                     _options.MinimumGlobalHeapCollectionSize, 
                     AlignSize(objectSize) + OBJECT_HEADER_SIZE + COLLECTION_HEADER_SIZE));
         }
 
+        var memory = collectionState.Memory;
+
         // encode object header
-        _index++;
+        collectionState.Index++;
 
         BitConverter
-            .GetBytes(_index)
-            .CopyTo(_memory.Span.Slice(collectionState.Consumed, sizeof(ushort)));
+            .GetBytes(collectionState.Index)
+            .CopyTo(memory.Span.Slice(collectionState.Consumed, sizeof(ushort)));
 
         collectionState.Consumed += sizeof(ushort);
 
         BitConverter
             .GetBytes((ushort)1)
-            .CopyTo(_memory.Span.Slice(collectionState.Consumed, sizeof(ushort)));
+            .CopyTo(memory.Span.Slice(collectionState.Consumed, sizeof(ushort)));
 
         collectionState.Consumed += sizeof(ushort);
         collectionState.Consumed += 4;
 
         BitConverter
             .GetBytes((ulong)objectSize)
-            .CopyTo(_memory.Span.Slice(collectionState.Consumed, sizeof(ulong)));
+            .CopyTo(memory.Span.Slice(collectionState.Consumed, sizeof(ulong)));
 
         collectionState.Consumed += sizeof(ulong);
 
         var globalHeapId = new WritingGlobalHeapId(
-            Address: (ulong)_baseAddress,
-            Index: _index
+            Address: (ulong)collectionState.BaseAddress,
+            Index: collectionState.Index
         );
 
         // object data
-        var data = _memory.Slice(collectionState.Consumed, objectSize);
+        var data = memory.Slice(collectionState.Consumed, objectSize);
 
         var alignedSize = AlignSize(objectSize);
         collectionState.Consumed += alignedSize;
@@ -89,7 +116,7 @@ internal class GlobalHeapManager
         return ALIGNMENT * ((objectSize + ALIGNMENT - 1) / ALIGNMENT);
     }
 
-    private GlobalHeapCollectionState AddNewCollection(int collectionSize)
+    private GlobalHeapCollectionState AddNewCollection(AllocationKind kind, int collectionSize)
     {
         // flush before we are able to continue
         if (
@@ -99,6 +126,10 @@ internal class GlobalHeapManager
         {
             Encode();
             _collectionMap.Clear();
+
+            // Every open collection has just been written and dropped from the map, so none of them may
+            // take another object - anything added to one afterwards would never be encoded again.
+            _openCollections.Clear();
         }
 
         // TODO make encoding and decoding of collection more symmetrical
@@ -109,18 +140,15 @@ internal class GlobalHeapManager
             CollectionSize = (ulong)collectionSize
         };
 
-        _baseAddress = _freeSpaceManager.Allocate(collectionSize, AllocationKind.Metadata);
-        _memory = new byte[collectionSize - COLLECTION_HEADER_SIZE];
-
-        //
-        _index = 0;
+        var baseAddress = _freeSpaceManager.Allocate(collectionSize, kind);
 
         var collectionState = new GlobalHeapCollectionState(
             Collection: collection,
-            Memory: _memory);
+            Memory: new byte[collectionSize - COLLECTION_HEADER_SIZE],
+            BaseAddress: baseAddress);
 
-        _collectionState = collectionState;
-        _collectionMap[_baseAddress] = collectionState;
+        _openCollections[kind] = collectionState;
+        _collectionMap[baseAddress] = collectionState;
 
         return collectionState;
     }
@@ -135,7 +163,7 @@ internal class GlobalHeapManager
         foreach (var entry in _collectionMap)
         {
             var address = entry.Key;
-            var (collection, memory) = entry.Value;
+            var (collection, memory, _) = entry.Value;
             var consumed = entry.Value.Consumed;
             var remainingSpace = (ulong)(memory.Length - consumed);
 

--- a/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
@@ -13,7 +13,47 @@ partial class H5NativeWriter
 
     private ulong _rootGroupAddress;
 
+    /// <summary>
+    /// Totals up how many bytes of structure <paramref name="file" /> needs, by encoding it against a
+    /// stream that discards everything.
+    /// </summary>
+    /// <remarks>
+    /// Exact rather than estimated, because it is the same encoder and the same allocator - so it
+    /// accounts for the things an estimate cannot, above all the global heap's 4 kB collection
+    /// granularity and a chunk index's dependence on chunk count. It does not compress, since no
+    /// metadata size depends on compressed output; see <see cref="NativeWriteContext.SizeOnly" />.
+    /// <para>
+    /// Chunk indexes are allocated when the writer is disposed rather than during encoding, so the total
+    /// is only complete after Dispose has run - hence the explicit call rather than a using block.
+    /// </para>
+    /// </remarks>
+    internal static long MeasureMetadataSize(H5File file, H5WriteOptions options)
+    {
+        var sizingOptions = options with
+        {
+            // Interleaved, so that this pass allocates no region of its own and the total it reports is
+            // purely the sum of what the file needs.
+            MetadataPlacement = H5MetadataPlacement.Interleaved,
+            MetadataReservation = 0
+        };
+
+        using var stream = new SizingStream();
+
+        var writer = new H5NativeWriter(file, stream, sizingOptions, leaveOpen: true, sizeOnly: true);
+
+        writer.Write();
+        writer.Dispose();
+
+        return writer.Context.FreeSpaceManager.MetadataAllocated;
+    }
+
     internal H5NativeWriter(H5File file, Stream stream, H5WriteOptions options, bool leaveOpen)
+        : this(file, stream, options, leaveOpen, sizeOnly: false)
+    {
+        //
+    }
+
+    private H5NativeWriter(H5File file, Stream stream, H5WriteOptions options, bool leaveOpen, bool sizeOnly)
     {
         // TODO readable is only required for checksums, maybe this requirement can be lifted by renting Memory<byte> and calculate the checksum over that memory
         if (!stream.CanRead || !stream.CanWrite || !stream.CanSeek)
@@ -39,8 +79,35 @@ partial class H5NativeWriter
                 throw new Exception("The user block size is invalid.");
         }
 
-        var freeSpaceManager = new FreeSpaceManager();
-        freeSpaceManager.Allocate(Superblock23.ENCODE_SIZE);
+        var freeSpaceManager = new FreeSpaceManager(
+            options.MetadataPlacement,
+            blockSize: options.MetadataPlacement == H5MetadataPlacement.Interleaved
+                ? 0
+                : options.MetadataBlockSize);
+
+        // The superblock must sit at offset zero, which is why it does not go through Allocate - see
+        // AllocateAtFront.
+        freeSpaceManager.AllocateAtFront(Superblock23.ENCODE_SIZE);
+
+        if (options.MetadataPlacement == H5MetadataPlacement.FrontLoaded && !sizeOnly)
+        {
+            // No reservation given: measure the file instead of guessing at it. The sizing pass runs
+            // Interleaved, so it cannot recurse back into this branch.
+            //
+            // SLACK is added to the measured figure and is not optional. The measurement is the total of
+            // every metadata allocation INCLUDING the superblock, but the superblock is allocated before
+            // the region exists and so is served from outside it - leaving the region short by exactly
+            // that much. Reserving the bare total exhausts the region to the byte and spills the final
+            // allocation into a whole extra block. The slack also absorbs the global heap's 4 kB
+            // collection granularity, which is the coarsest thing the allocator hands out.
+            const long slack = 3 * 4096;
+
+            var reservation = options.MetadataReservation > 0
+                ? options.MetadataReservation
+                : MeasureMetadataSize(file, options) + slack;
+
+            freeSpaceManager.ReserveMetadataRegion(reservation);
+        }
 
         var globalHeapManager = new GlobalHeapManager(options, freeSpaceManager, driver);
 
@@ -58,7 +125,10 @@ partial class H5NativeWriter
             ObjectReferenceCountMap: new(),
             RawValueToDatasetMap: new(ReferenceEqualityComparer.Instance),
             ShortlivedStream: new(memory: default)
-        );
+        )
+        {
+            SizeOnly = sizeOnly
+        };
 
         File = file;
         Context = writeContext;

--- a/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
@@ -79,6 +79,16 @@ partial class H5NativeWriter
                 throw new Exception("The user block size is invalid.");
         }
 
+        if (options.MetadataReservation < 0)
+            throw new Exception("The metadata reservation must not be negative.");
+
+        // Only meaningful away from Interleaved, which passes zero deliberately below. Rejected rather
+        // than tolerated because a non-positive ceiling silently turns Aggregated into Interleaved: the
+        // block path is gated on a positive size, so the caller asks for clustering and gets none, with
+        // nothing to indicate why.
+        if (options.MetadataPlacement != H5MetadataPlacement.Interleaved && options.MetadataBlockSize <= 0)
+            throw new Exception("The metadata block size must be greater than zero.");
+
         var freeSpaceManager = new FreeSpaceManager(
             options.MetadataPlacement,
             blockSize: options.MetadataPlacement == H5MetadataPlacement.Interleaved

--- a/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
@@ -94,17 +94,15 @@ partial class H5NativeWriter
             // No reservation given: measure the file instead of guessing at it. The sizing pass runs
             // Interleaved, so it cannot recurse back into this branch.
             //
-            // SLACK is added to the measured figure and is not optional. The measurement is the total of
-            // every metadata allocation INCLUDING the superblock, but the superblock is allocated before
-            // the region exists and so is served from outside it - leaving the region short by exactly
-            // that much. Reserving the bare total exhausts the region to the byte and spills the final
-            // allocation into a whole extra block. The slack also absorbs the global heap's 4 kB
-            // collection granularity, which is the coarsest thing the allocator hands out.
-            const long slack = 3 * 4096;
-
+            // The superblock is subtracted because the measurement totals every metadata allocation
+            // INCLUDING it, while the superblock is allocated before the region exists and so is served
+            // from outside it - leaving the region longer than anything will ever ask of it by exactly
+            // that much. Subtracting makes the reservation the exact number of bytes that will be served
+            // from it, which is what lets a front-loaded file come out the same size as an interleaved
+            // one rather than merely close to it.
             var reservation = options.MetadataReservation > 0
                 ? options.MetadataReservation
-                : MeasureMetadataSize(file, options) + slack;
+                : MeasureMetadataSize(file, options) - Superblock23.ENCODE_SIZE;
 
             freeSpaceManager.ReserveMetadataRegion(reservation);
         }

--- a/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
@@ -509,7 +509,7 @@ partial class H5NativeWriter
 
         h5d.Initialize();
 
-        if (!memoryData.Equals(default))
+        if (!memoryData.Equals(default) && (!Context.SizeOnly || SizingPassNeedsData<TElement>(dataLayout)))
         {
             WriteData(
                 h5d,
@@ -536,6 +536,40 @@ partial class H5NativeWriter
         Context.DatasetInfoToObjectHeaderMap[datasetInfo] = ((long)address, (int)(end - address));
 
         return address;
+    }
+
+    /// <summary>
+    /// Whether a sizing pass has to encode this dataset's data, or can leave it alone.
+    /// </summary>
+    /// <remarks>
+    /// The pass exists to total up metadata, so it only has to do work that decides how much metadata
+    /// there is. Copying fixed-size payload into a layout decides nothing: a contiguous region and an
+    /// implicit chunk index are raw data, a fixed-array index is sized from the chunk count, and every
+    /// index's encoded width comes from the dataspace rather than from a value. So for fixed-size
+    /// elements the pass skips the whole data path - no selection walk, no chunk buffers, no byte
+    /// copying, no raw chunk allocation - on top of already skipping compression.
+    /// <para>
+    /// What it cannot skip is data whose encoding allocates. That is why the test is on TElement rather
+    /// than on the dataset type: an array is itself a reference, so asking this of the dataset type
+    /// answers yes for every array-backed dataset and the pass would skip nothing.
+    /// </para>
+    /// </remarks>
+    private static bool SizingPassNeedsData<TElement>(DataLayoutMessage4 dataLayout)
+    {
+        // A compact dataset's payload is embedded in its object header, so here the data IS metadata.
+        // Nothing to save either way - compact is capped at 64 kB.
+        if (dataLayout.Properties is CompactStoragePropertyDescription)
+            return true;
+
+        // Anything holding a reference goes through the per-element encoder, which allocates: a
+        // variable-length string or sequence takes global heap space sized from the values themselves,
+        // and an object reference encodes the object it points at, header and all.
+        if (DataUtils.IsReferenceOrContainsReferences(typeof(TElement)))
+            return true;
+
+        // Nullable<T> is encoded as a variable-length sequence of one, so it takes global heap space
+        // too - and contains no reference, so the check above does not see it.
+        return Nullable.GetUnderlyingType(typeof(TElement)) is not null;
     }
 
     private static void InternalWriteDataset<T, TElement>(

--- a/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/H5NativeWriter.cs
@@ -509,13 +509,27 @@ partial class H5NativeWriter
 
         if (!memoryData.Equals(default) && (!Context.SizeOnly || SizingPassNeedsData<TElement>(dataLayout)))
         {
-            WriteData(
-                h5d,
-                encode,
-                memoryData,
-                dataset.FileSelection,
-                dataset.MemorySelection,
-                memoryDims ?? throw new Exception("This should never happen."));
+            // Variable-length elements encoded from here belong to the dataset, so the heap collections
+            // holding them are payload rather than structure. Restored rather than left set, because an
+            // object reference among these elements encodes the object it points at, attributes and all.
+            var enclosing = Context.GlobalHeapManager.AllocationKind;
+            Context.GlobalHeapManager.AllocationKind = AllocationKind.RawData;
+
+            try
+            {
+                WriteData(
+                    h5d,
+                    encode,
+                    memoryData,
+                    dataset.FileSelection,
+                    dataset.MemorySelection,
+                    memoryDims ?? throw new Exception("This should never happen."));
+            }
+
+            finally
+            {
+                Context.GlobalHeapManager.AllocationKind = enclosing;
+            }
         }
 
         Context.DatasetToInfoMap[dataset] = (h5d, encode);

--- a/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/NativeWriteContext.cs
@@ -28,4 +28,18 @@ internal record NativeWriteContext(
     Dictionary<H5Object, int> ObjectReferenceCountMap,
     Dictionary<object, H5Dataset> RawValueToDatasetMap,
     SystemMemoryStream ShortlivedStream
-);
+)
+{
+    /// <summary>
+    /// Set for the pass whose only purpose is to total up how much structure the file needs, so that a
+    /// front-loaded reservation can be sized exactly instead of estimated.
+    /// </summary>
+    /// <remarks>
+    /// Everything that decides a SIZE still runs: every object is encoded, every chunk is enumerated and
+    /// allocated, every heap collection is opened. What is skipped is compressing chunk payload, because
+    /// no metadata size depends on the compressed result - a filtered chunk index entry's size field is
+    /// sized from <c>ChunkByteSize</c>, the uncompressed chunk size - and compression is around 97% of a
+    /// filtered write, so running it would make the pass cost as much as the file it is measuring.
+    /// </remarks>
+    public bool SizeOnly { get; init; }
+}

--- a/src/PureHDF/VOL/Native/Core.Writing/SizingStream.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/SizingStream.cs
@@ -1,0 +1,97 @@
+namespace PureHDF.VOL.Native;
+
+/// <summary>
+/// A seekable stream that discards everything written to it and reads back zeroes, used by the sizing
+/// pass that decides how much space to reserve for file structure.
+/// </summary>
+/// <remarks>
+/// It tracks position and length so that the writer behaves exactly as it would against a real stream -
+/// the writer allocates every address up front and then seeks to it, so nothing it does depends on the
+/// bytes already there. Reads exist only because the writer verifies checksums by reading back what it
+/// wrote; a checksum computed over zeroes is wrong, but a checksum's SIZE is fixed, and size is all this
+/// pass is measuring.
+/// <para>
+/// Not a MemoryStream, deliberately: the point is to measure a file without materialising it, and a
+/// 620 MB file would otherwise be buffered in memory to learn how big its structure is.
+/// </para>
+/// </remarks>
+internal sealed class SizingStream : Stream
+{
+    private long _position;
+    private long _length;
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => true;
+
+    public override long Length => _length;
+
+    public override long Position
+    {
+        get => _position;
+        set => _position = value;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        Advance(count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        Advance(buffer.Length);
+    }
+
+    public override void WriteByte(byte value)
+    {
+        Advance(1);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        // Zeroes rather than a short read: the writer expects to get back as much as it asks for, and a
+        // short read would send it down an error path that has nothing to do with what is being measured.
+        buffer.Clear();
+        _position += buffer.Length;
+
+        return buffer.Length;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        _position = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+
+        return _position;
+    }
+
+    public override void SetLength(long value)
+    {
+        _length = value;
+    }
+
+    public override void Flush()
+    {
+        //
+    }
+
+    private void Advance(int count)
+    {
+        _position += count;
+
+        if (_position > _length)
+            _length = _position;
+    }
+}

--- a/src/PureHDF/VOL/Native/Core.Writing/WriteTypes.cs
+++ b/src/PureHDF/VOL/Native/Core.Writing/WriteTypes.cs
@@ -7,9 +7,15 @@ internal delegate void ElementEncodeDelegate(object source, IH5WriteStream targe
 
 internal record GlobalHeapCollectionState(
     GlobalHeapCollection Collection,
-    Memory<byte> Memory)
+    Memory<byte> Memory,
+    long BaseAddress)
 {
     public int Consumed { get; set; }
+
+    // Per collection rather than per manager: object indices restart at 1 in each collection, and the
+    // manager now keeps one collection open per allocation kind, so a single counter would interleave
+    // two collections' indices and mislabel their objects.
+    public ushort Index { get; set; }
 };
 
 [StructLayout(LayoutKind.Explicit, Size = 12)]

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Attribute/AttributeMessage.Writing.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Attribute/AttributeMessage.Writing.cs
@@ -83,7 +83,23 @@ internal partial record class AttributeMessage
             InputData: default,
             EncodeData: driver =>
             {
-                encode(memoryData, localWriter);
+                // An attribute's value is structure: it is what a viewer reads while browsing, rather
+                // than while reading a dataset. Set explicitly rather than relied upon, since this can
+                // run inside a dataset's data write - an object reference encodes the object it points
+                // at, and that object's attributes are still attributes.
+                var enclosing = context.GlobalHeapManager.AllocationKind;
+                context.GlobalHeapManager.AllocationKind = AllocationKind.Metadata;
+
+                try
+                {
+                    encode(memoryData, localWriter);
+                }
+
+                finally
+                {
+                    context.GlobalHeapManager.AllocationKind = enclosing;
+                }
+
                 driver.Write(buffer);
             }
         )

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/DataLayoutMessage4.Writing.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/DataLayout/DataLayoutMessage4.Writing.cs
@@ -23,7 +23,7 @@ internal partial record class DataLayoutMessage4
                     .Ceiling(dataDimensions[dimension] / (double)chunkDimensions[dimension]);
             }
 
-            (IndexingInformation IndexingInformation, long EncodeSize, ChunkedStoragePropertyFlags Flags) indexInfo;
+            (IndexingInformation IndexingInformation, long EncodeSize, AllocationKind Kind, ChunkedStoragePropertyFlags Flags) indexInfo;
 
             if (chunkCount == 1)
             {
@@ -37,6 +37,7 @@ internal partial record class DataLayoutMessage4
                 indexInfo = (
                     indexingInformation,
                     0,
+                    AllocationKind.Metadata,
                     flags);
             }
 
@@ -50,6 +51,7 @@ internal partial record class DataLayoutMessage4
                                 PageBits: (byte)Math.Ceiling(Math.Log2(chunkCount))
                             ),
                             FixedArrayHeader.ENCODE_SIZE,
+                            AllocationKind.Metadata,
                             ChunkedStoragePropertyFlags.None
                         )
                     :
@@ -60,6 +62,13 @@ internal partial record class DataLayoutMessage4
                                 chunkDimensions.Aggregate(1UL, (product, dimension) => product * dimension) * 
                                 typeSize
                             ),
+
+                            /* An implicit index has no index structure at all: the chunks sit
+                             * contiguously from this address, so what is allocated here is the whole
+                             * payload rather than metadata. See H5D_Chunk4_Implicit, which derives a
+                             * chunk's address by offsetting into it arithmetically.
+                             */
+                            AllocationKind.RawData,
                             ChunkedStoragePropertyFlags.None
                         );
             }
@@ -67,7 +76,7 @@ internal partial record class DataLayoutMessage4
             /* some indexes can only be allocated later */
             var address = indexInfo.EncodeSize == 0
                 ? Superblock.UndefinedAddress
-                : (ulong)context.FreeSpaceManager.Allocate(indexInfo.EncodeSize);
+                : (ulong)context.FreeSpaceManager.Allocate(indexInfo.EncodeSize, indexInfo.Kind);
 
             var properties = new ChunkedStoragePropertyDescription4(
                 Rank: (byte)(chunkDimensions.Length + 1),
@@ -142,7 +151,7 @@ internal partial record class DataLayoutMessage4
             /* create contiguous dataset */
             if (dataLayout == default)
             {
-                var address = context.FreeSpaceManager.Allocate(dataEncodeSize);
+                var address = context.FreeSpaceManager.Allocate(dataEncodeSize, AllocationKind.RawData);
 
                 var properties = new ContiguousStoragePropertyDescription(
                     Size: (ulong)dataEncodeSize

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderPrefix/ObjectHeader2.Writing.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderPrefix/ObjectHeader2.Writing.cs
@@ -10,7 +10,7 @@ internal partial record class ObjectHeader2
         var encodeSize = GetEncodeSize(headerMessagesEncodeSize);
 
         var freeSpaceManager = context.FreeSpaceManager;
-        var address = freeSpaceManager.Allocate((long)encodeSize);
+        var address = freeSpaceManager.Allocate((long)encodeSize, AllocationKind.Metadata);
 
         var driver = context.Driver;
         driver.SeekRelativeToBaseAddress(address);

--- a/src/PureHDF/VOL/Native/H5D/H5D_Chunk.cs
+++ b/src/PureHDF/VOL/Native/H5D/H5D_Chunk.cs
@@ -315,6 +315,21 @@ internal abstract class H5D_Chunk : H5D_Base
         {
             var filterMask = 0U;
 
+            // A sizing pass registers the chunk without compressing it. Registering it is required,
+            // because the index's size comes from how many chunks there are - but the compressed length
+            // is not, because the width of an index entry's size field comes from ChunkSizeLength, which
+            // is computed from the UNCOMPRESSED ChunkByteSize. Passing the uncompressed length is
+            // therefore both consistent with that width and an upper bound.
+            //
+            // This is the one thing such a pass must skip: compression is around 97% of a filtered
+            // write, so running it would cost as much as the write being measured.
+            if (WriteContext.SizeOnly)
+            {
+                _ = GetWriteChunkInfo(chunkIndex, (uint)ChunkByteSize, filterMask);
+
+                return;
+            }
+
             var buffer = H5Filter.ExecutePipeline(
                 Dataset.FilterPipeline.FilterDescriptions,
                 filterMask,

--- a/src/PureHDF/VOL/Native/H5D/H5D_Chunk4_FixedArray.cs
+++ b/src/PureHDF/VOL/Native/H5D/H5D_Chunk4_FixedArray.cs
@@ -81,7 +81,7 @@ internal class H5D_Chunk4_FixedArray : H5D_Chunk4
         if (Dataset.FilterPipeline is not null)
         {
             chunkInfo = new ChunkInfo(
-                Address: (ulong)WriteContext.FreeSpaceManager.Allocate(chunkSize),
+                Address: (ulong)WriteContext.FreeSpaceManager.Allocate(chunkSize, AllocationKind.RawData),
                 Size: chunkSize,
                 FilterMask: filterMask
             );
@@ -139,7 +139,7 @@ internal class H5D_Chunk4_FixedArray : H5D_Chunk4
                 };
 
                 var dataBlockEncodeSize = dataBlock.GetEncodeSize(pageCount, pageBitmapSize, entrySize);
-                var dataBlockAddress = WriteContext.FreeSpaceManager.Allocate((long)dataBlockEncodeSize);
+                var dataBlockAddress = WriteContext.FreeSpaceManager.Allocate((long)dataBlockEncodeSize, AllocationKind.Metadata);
 
                 var header = new FixedArrayHeader(
                     Superblock: default!,

--- a/src/PureHDF/VOL/Native/H5D/H5D_Chunk4_SingleChunk.cs
+++ b/src/PureHDF/VOL/Native/H5D/H5D_Chunk4_SingleChunk.cs
@@ -29,7 +29,7 @@ internal class H5Dataset_Chunk_Single_Chunk4 : H5D_Chunk4
     protected override ChunkInfo GetActualWriteChunkInfo(ulong chunkIndex, uint chunkSize, uint filterMask)
     {
         /* see also H5D__single_idx_insert (H5DSingle.c) */
-        Chunked4.Address = (ulong)WriteContext.FreeSpaceManager.Allocate(chunkSize);
+        Chunked4.Address = (ulong)WriteContext.FreeSpaceManager.Allocate(chunkSize, AllocationKind.RawData);
 
         var single = (SingleChunkIndexingInformation)Chunked4.IndexingInformation;
         single.FilteredChunkSize = chunkSize;

--- a/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
+++ b/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
@@ -1,0 +1,202 @@
+using System.Diagnostics;
+using PureHDF.Filters;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PureHDF.Tests.Reading;
+
+/// <summary>
+/// What it costs a remote client to open a file - round trips and bytes - and how much of that cost is
+/// decided by where the writer put the structure.
+/// </summary>
+/// <remarks>
+/// The read path is asynchronous, so a file can be range-read over a network transport - but whether that
+/// is practical depends on what a full structure walk actually pulls over the wire, which is a property of
+/// how the file was written rather than of the reader.
+/// <para>
+/// Attribute VALUES are deliberately not read. PureHDF stores attributes compactly, so an attribute's
+/// value sits in the same object header as its name and datatype - already in a block the walk fetched -
+/// and reading it costs no additional request. The exception is a variable-length value, which lives in
+/// the global heap; the numeric attributes used here have none, so the walk below is the whole
+/// metadata cost rather than most of it.
+/// </para>
+/// </remarks>
+public class RangeReadCostTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Block size for the controlled comparison. Smaller than the 1 MiB a real range client typically
+    /// fetches, because a synthetic file small enough to write in a unit test spans only a handful of
+    /// 1 MiB blocks - too few for a difference in locality to be expressible at all.
+    /// </summary>
+    private const long ControlBlockSize = 256 * 1024;
+
+    private const int GroupCount = 600;
+
+    /// <param name="MaxDatasetBytes">
+    ///     Largest single dataset, uncompressed, from its shape and type alone - an upper bound on what a
+    ///     client must fetch to read one dataset whole, since a filtered chunk cannot be partially
+    ///     decompressed and so even a strided read pulls every chunk it spans.
+    /// </param>
+    private sealed record WalkResult(
+        int Groups,
+        int Datasets,
+        int Attributes,
+        long MaxDatasetBytes,
+        long TotalDatasetBytes);
+
+    /// <summary>
+    /// Builds a tree shaped like a report: many small groups, each carrying attributes and a dataset.
+    /// </summary>
+    private static H5File BuildTree()
+    {
+        var root = new H5File();
+
+        for (var i = 0; i < GroupCount; i++)
+        {
+            var data = new int[4_096];
+
+            for (var j = 0; j < data.Length; j++)
+            {
+                // Varied, because deflate over a run of zeroes compresses unrepresentatively well and
+                // would leave the file too small for block-level effects to show.
+                data[j] = (i * 31) + (j * 7);
+            }
+
+            root[$"unit{i:D4}"] = new H5Group
+            {
+                Attributes = new Dictionary<string, object>
+                {
+                    ["index"] = i,
+                    ["scale"] = i * 1.5,
+                },
+                ["values"] = new H5Dataset(data)
+            };
+        }
+
+        return root;
+    }
+
+    /// <summary>
+    /// Walks every group, dataset and attribute, touching each dataset's shape and type - the same
+    /// metadata-only traversal a viewer performs to build its tree and decide what is plottable.
+    /// </summary>
+    private static async Task<WalkResult> WalkAsync(IH5Group group)
+    {
+        var groups = 1;
+        var datasets = 0;
+        var attributes = (await group.AttributesAsync()).Count();
+        var maxDatasetBytes = 0L;
+        var totalDatasetBytes = 0L;
+
+        foreach (var child in await group.ChildrenAsync())
+        {
+            switch (child)
+            {
+                case IH5Group childGroup:
+                    var nested = await WalkAsync(childGroup);
+                    groups += nested.Groups;
+                    datasets += nested.Datasets;
+                    attributes += nested.Attributes;
+                    maxDatasetBytes = Math.Max(maxDatasetBytes, nested.MaxDatasetBytes);
+                    totalDatasetBytes += nested.TotalDatasetBytes;
+                    break;
+
+                case IH5Dataset dataset:
+                    datasets++;
+
+                    var elements = dataset.Space.Dimensions.Aggregate(1UL, (product, length) => product * length);
+                    var bytes = (long)elements * dataset.Type.Size;
+
+                    maxDatasetBytes = Math.Max(maxDatasetBytes, bytes);
+                    totalDatasetBytes += bytes;
+
+                    attributes += (await dataset.AttributesAsync()).Count();
+                    break;
+            }
+        }
+
+        return new WalkResult(groups, datasets, attributes, maxDatasetBytes, totalDatasetBytes);
+    }
+
+    private async Task<(WalkResult Walk, int Requests, long Bytes, int Blocks, long Milliseconds)> MeasureWalkAsync(
+        string filePath,
+        long blockSize)
+    {
+        using var stream = new RangeRequestStream(filePath, blockSize);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        using var file = await H5File.OpenAsync(stream, leaveOpen: true);
+
+        var walk = await WalkAsync(file);
+
+        stopwatch.Stop();
+
+        return (walk, stream.Requests, stream.BytesFetched, stream.BlocksResident, stopwatch.ElapsedMilliseconds);
+    }
+
+    private void Report(string label, string filePath, (WalkResult Walk, int Requests, long Bytes, int Blocks, long Milliseconds) result)
+    {
+        var size = new FileInfo(filePath).Length;
+
+        output.WriteLine(
+            $"{label,-14} file {size,13:N0} B | fetched {result.Bytes,13:N0} B "
+            + $"({(double)result.Bytes / size,6:P1} of file) | {result.Requests,6:N0} requests "
+            + $"| {result.Blocks,5:N0} blocks resident | {result.Milliseconds,6:N0} ms "
+            + $"| {result.Walk.Groups:N0} groups, {result.Walk.Datasets:N0} datasets, {result.Walk.Attributes:N0} attributes");
+    }
+
+    /// <summary>
+    /// The same content written both ways, so the only variable is where the structure went.
+    /// </summary>
+    [Fact]
+    public async Task AFrontLoadedFileIsFarCheaperToWalkRemotelyThanAnInterleavedOne()
+    {
+        // Arrange - deflate forces chunked layout, without which these datasets would be stored
+        // compact (payload inside the object header) and there would be no separation to measure.
+        var interleavedPath = Path.GetTempFileName();
+        var frontLoadedPath = Path.GetTempFileName();
+
+        try
+        {
+            BuildTree().Write(
+                interleavedPath,
+                new H5WriteOptions(Filters: [DeflateFilter.Id]) { MetadataPlacement = H5MetadataPlacement.Interleaved });
+
+            BuildTree().Write(
+                frontLoadedPath,
+                new H5WriteOptions(Filters: [DeflateFilter.Id]) { MetadataPlacement = H5MetadataPlacement.FrontLoaded });
+
+            // Act
+            var interleaved = await MeasureWalkAsync(interleavedPath, ControlBlockSize);
+            var frontLoaded = await MeasureWalkAsync(frontLoadedPath, ControlBlockSize);
+
+            Report("interleaved", interleavedPath, interleaved);
+            Report("front-loaded", frontLoadedPath, frontLoaded);
+
+            // Assert - the walk must see the same file both ways, or the comparison is meaningless.
+            Assert.Equal(interleaved.Walk, frontLoaded.Walk);
+            Assert.Equal(GroupCount, frontLoaded.Walk.Datasets);
+
+            // The file has to be big enough in blocks for locality to be expressible at all.
+            var blocksInFile = (new FileInfo(interleavedPath).Length + ControlBlockSize - 1) / ControlBlockSize;
+            Assert.True(blocksInFile > 8, $"the file spans only {blocksInFile} blocks, too few to measure locality");
+
+            Assert.True(
+                frontLoaded.Bytes < interleaved.Bytes / 2,
+                $"front-loading must at least halve what a remote walk transfers, but it fetched "
+                + $"{frontLoaded.Bytes:N0} B against {interleaved.Bytes:N0} B");
+
+            Assert.True(
+                frontLoaded.Blocks < interleaved.Blocks,
+                $"a front-loaded walk must hold fewer blocks, but it held {frontLoaded.Blocks} against "
+                + $"{interleaved.Blocks}");
+        }
+
+        finally
+        {
+            File.Delete(interleavedPath);
+            File.Delete(frontLoadedPath);
+        }
+    }
+}

--- a/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
+++ b/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
@@ -233,6 +233,18 @@ public class RangeReadCostTests(ITestOutputHelper output)
                 $"a measured reservation fetched {frontLoaded.Bytes:N0} B against aggregation's "
                 + $"{aggregated.Bytes:N0} B, so measuring the file bought nothing");
 
+            // Round trips, which is what the whole exercise is about and what every figure quoted for
+            // this feature is stated in. A measured reservation is one contiguous span, so walking the
+            // structure is one request; asserted as a number rather than a ratio because the number is
+            // the claim. Aggregation clusters into a handful, and interleaving needs one per block it
+            // spans.
+            Assert.Equal(1, frontLoaded.Requests);
+
+            Assert.True(
+                aggregated.Requests > 1 && aggregated.Requests * 4 < interleaved.Requests,
+                $"aggregation took {aggregated.Requests} requests against interleaving's "
+                + $"{interleaved.Requests}, which is not the handful-against-all-of-them this reports");
+
             // What aggregation must not do is buy that locality with file size. Blocks are claimed in
             // full, so a block of fixed size is a floor rather than a proportional cost: at the 8 MB
             // default this file came out three times larger, which is a bad trade however few ranges it

--- a/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
+++ b/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
@@ -47,19 +47,37 @@ public class RangeReadCostTests(ITestOutputHelper output)
     /// <summary>
     /// Builds a tree shaped like a report: many small groups, each carrying attributes and a dataset.
     /// </summary>
+    /// <remarks>
+    /// The payload is a periodic signal with a slow drift, rounded to two decimals - a measurement
+    /// series, which is what these files hold. Its shape is chosen for how it compresses, since the file
+    /// sizes reported below are only as meaningful as the payload is representative. Three properties
+    /// matter, and a plainer choice fails at least one:
+    /// <list type="bullet">
+    /// <item>It compresses, to about 39%, so the file is neither dominated by payload nor unrealistically
+    /// small - a run of zeroes compresses away to nothing and leaves too few blocks for locality to be
+    /// expressible at all.</item>
+    /// <item>It compresses to nearly the same size on every runtime. .NET 9 replaced the bundled zlib
+    /// with zlib-ng, whose match finder differs below maximum effort, so a payload can compress quite
+    /// differently across target frameworks: this one lands within 0.2%, where a strided integer ramp -
+    /// pathological for a fast match finder - differed by 73% and moved every figure here with it.</item>
+    /// <item>It is deterministic, so the figures are reproducible rather than merely typical.</item>
+    /// </list>
+    /// The rounding is what buys the compression: full-mantissa doubles differ in their low bytes at
+    /// every sample and barely compress at all.
+    /// </remarks>
     private static H5File BuildTree()
     {
         var root = new H5File();
 
         for (var i = 0; i < GroupCount; i++)
         {
-            var data = new int[4_096];
+            // 2,048 doubles is the same 16 kB of payload per group that an int array of twice the
+            // length would be, so the file stays the size the block arithmetic above assumes.
+            var data = new double[2_048];
 
             for (var j = 0; j < data.Length; j++)
             {
-                // Varied, because deflate over a run of zeroes compresses unrepresentatively well and
-                // would leave the file too small for block-level effects to show.
-                data[j] = (i * 31) + (j * 7);
+                data[j] = Math.Round(Math.Sin((j + i) / 50.0) * 100 + (j * 0.01), 2);
             }
 
             root[$"unit{i:D4}"] = new H5Group

--- a/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
+++ b/tests/PureHDF.Tests/Reading/RangeReadCostTests.cs
@@ -147,34 +147,45 @@ public class RangeReadCostTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// The same content written both ways, so the only variable is where the structure went.
+    /// The same content written every way, so the only variable is where the structure went.
     /// </summary>
+    /// <remarks>
+    /// Both clustered placements are measured, not just the best one. They answer different questions: a
+    /// reservation is sized by measuring the file first and gets the structure into one range, while
+    /// aggregation needs no such pass and settles for a handful. A caller choosing between them wants the
+    /// gap between the two, and a caller who cannot afford the sizing pass wants to know that aggregation
+    /// is still worth having - neither of which a two-way comparison against interleaving shows.
+    /// </remarks>
     [Fact]
-    public async Task AFrontLoadedFileIsFarCheaperToWalkRemotelyThanAnInterleavedOne()
+    public async Task EveryClusteredPlacementIsFarCheaperToWalkRemotelyThanInterleaving()
     {
         // Arrange - deflate forces chunked layout, without which these datasets would be stored
         // compact (payload inside the object header) and there would be no separation to measure.
         var interleavedPath = Path.GetTempFileName();
+        var aggregatedPath = Path.GetTempFileName();
         var frontLoadedPath = Path.GetTempFileName();
 
         try
         {
-            BuildTree().Write(
-                interleavedPath,
-                new H5WriteOptions(Filters: [DeflateFilter.Id]) { MetadataPlacement = H5MetadataPlacement.Interleaved });
+            void Write(string filePath, H5MetadataPlacement placement) => BuildTree().Write(
+                filePath,
+                new H5WriteOptions(Filters: [DeflateFilter.Id]) { MetadataPlacement = placement });
 
-            BuildTree().Write(
-                frontLoadedPath,
-                new H5WriteOptions(Filters: [DeflateFilter.Id]) { MetadataPlacement = H5MetadataPlacement.FrontLoaded });
+            Write(interleavedPath, H5MetadataPlacement.Interleaved);
+            Write(aggregatedPath, H5MetadataPlacement.Aggregated);
+            Write(frontLoadedPath, H5MetadataPlacement.FrontLoaded);
 
             // Act
             var interleaved = await MeasureWalkAsync(interleavedPath, ControlBlockSize);
+            var aggregated = await MeasureWalkAsync(aggregatedPath, ControlBlockSize);
             var frontLoaded = await MeasureWalkAsync(frontLoadedPath, ControlBlockSize);
 
             Report("interleaved", interleavedPath, interleaved);
+            Report("aggregated", aggregatedPath, aggregated);
             Report("front-loaded", frontLoadedPath, frontLoaded);
 
-            // Assert - the walk must see the same file both ways, or the comparison is meaningless.
+            // Assert - the walk must see the same file every way, or the comparison is meaningless.
+            Assert.Equal(interleaved.Walk, aggregated.Walk);
             Assert.Equal(interleaved.Walk, frontLoaded.Walk);
             Assert.Equal(GroupCount, frontLoaded.Walk.Datasets);
 
@@ -191,11 +202,37 @@ public class RangeReadCostTests(ITestOutputHelper output)
                 frontLoaded.Blocks < interleaved.Blocks,
                 $"a front-loaded walk must hold fewer blocks, but it held {frontLoaded.Blocks} against "
                 + $"{interleaved.Blocks}");
+
+            // Aggregation has to earn its place without a sizing pass.
+            Assert.True(
+                aggregated.Bytes < interleaved.Bytes / 2,
+                $"aggregation must at least halve what a remote walk transfers, but it fetched "
+                + $"{aggregated.Bytes:N0} B against {interleaved.Bytes:N0} B");
+
+            // Measuring the file cannot do worse than not measuring it.
+            Assert.True(
+                frontLoaded.Bytes <= aggregated.Bytes,
+                $"a measured reservation fetched {frontLoaded.Bytes:N0} B against aggregation's "
+                + $"{aggregated.Bytes:N0} B, so measuring the file bought nothing");
+
+            // What aggregation must not do is buy that locality with file size. Blocks are claimed in
+            // full, so a block of fixed size is a floor rather than a proportional cost: at the 8 MB
+            // default this file came out three times larger, which is a bad trade however few ranges it
+            // takes to walk. Growth is bounded from the reader's side here and from the writer's side in
+            // MetadataLayoutTests.
+            var interleavedSize = new FileInfo(interleavedPath).Length;
+            var aggregatedSize = new FileInfo(aggregatedPath).Length;
+
+            Assert.True(
+                aggregatedSize < interleavedSize * 1.1,
+                $"aggregation produced {aggregatedSize:N0} bytes against {interleavedSize:N0} interleaved, "
+                + $"so a whole block is being claimed regardless of how little metadata the file has");
         }
 
         finally
         {
             File.Delete(interleavedPath);
+            File.Delete(aggregatedPath);
             File.Delete(frontLoadedPath);
         }
     }

--- a/tests/PureHDF.Tests/Reading/RangeRequestStream.cs
+++ b/tests/PureHDF.Tests/Reading/RangeRequestStream.cs
@@ -1,0 +1,165 @@
+namespace PureHDF.Tests.Reading;
+
+/// <summary>
+/// An <see cref="IConcurrentStream" /> that serves reads from a file on disk while counting what an HTTP
+/// range-request client would have had to fetch to answer them.
+/// </summary>
+/// <remarks>
+/// A remote reader cannot issue one request per struct field, so it fetches fixed-size blocks and keeps
+/// them. That block model is what makes these numbers transferable to a real HTTP or object-store client.
+/// <para>
+/// The counters are the point. <see cref="Requests" /> is round trips - contiguous missing blocks
+/// coalesce into one, since a range request can span them - and <see cref="BytesFetched" /> is
+/// transfer volume. They move independently: a walk can be cheap in bytes and ruinous in round trips,
+/// or the reverse, and only the two together say whether a source is usable over a network.
+/// </para>
+/// <para>
+/// Blocks are retained without limit, deliberately. This measures the LOWER BOUND on what a file's
+/// layout forces a client to fetch; adding eviction would fold a cache-sizing policy into a number that
+/// is supposed to be about the file. A client with a bounded cache can only do worse, since a block it
+/// evicts and needs again costs a second request.
+/// </para>
+/// <para>
+/// A bare <see cref="IConcurrentStream" /> with no <see cref="Stream" /> base, as in
+/// <see cref="ConcurrentStream" />: there is no cursor to read through, so no read can slip past the
+/// counters, and silently wrong numbers are worse than no numbers.
+/// </para>
+/// </remarks>
+internal sealed class RangeRequestStream : IConcurrentStream
+{
+    private readonly FileStream _file;
+    private readonly long _blockSize;
+    private readonly HashSet<long> _resident = [];
+    private readonly object _gate = new();
+
+    private int _requests;
+    private long _bytesFetched;
+    private int _metadataReads;
+    private int _datasetReads;
+
+    public RangeRequestStream(string filePath, long blockSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(blockSize, 1);
+
+        _file = File.OpenRead(filePath);
+        _blockSize = blockSize;
+    }
+
+    /// <summary>Range requests a client would have issued, contiguous blocks counted once.</summary>
+    public int Requests => Volatile.Read(ref _requests);
+
+    /// <summary>Bytes those requests would have transferred.</summary>
+    public long BytesFetched => Volatile.Read(ref _bytesFetched);
+
+    /// <summary>Distinct blocks a client would be holding, i.e. its peak memory in blocks.</summary>
+    public int BlocksResident
+    {
+        get
+        {
+            lock (_gate)
+                return _resident.Count;
+        }
+    }
+
+    public int MetadataReadCount => Volatile.Read(ref _metadataReads);
+
+    public int DatasetReadCount => Volatile.Read(ref _datasetReads);
+
+    public void ResetCounts()
+    {
+        Volatile.Write(ref _requests, 0);
+        Volatile.Write(ref _bytesFetched, 0);
+        Volatile.Write(ref _metadataReads, 0);
+        Volatile.Write(ref _datasetReads, 0);
+    }
+
+    /// <summary>Drops the block cache too, for measuring a cold open rather than a warm one.</summary>
+    public void ResetAll()
+    {
+        ResetCounts();
+
+        lock (_gate)
+            _resident.Clear();
+    }
+
+    public ValueTask ReadDatasetAsync(long offset, Memory<byte> buffer)
+    {
+        Interlocked.Increment(ref _datasetReads);
+
+        return ReadCore(offset, buffer);
+    }
+
+    public ValueTask ReadMetadataAsync(long offset, Memory<byte> buffer)
+    {
+        Interlocked.Increment(ref _metadataReads);
+
+        return ReadCore(offset, buffer);
+    }
+
+    public long Length => _file.Length;
+
+    public void Dispose()
+    {
+        _file.Dispose();
+    }
+
+    private ValueTask ReadCore(long offset, Memory<byte> buffer)
+    {
+        if (buffer.Length == 0)
+            return default;
+
+        lock (_gate)
+        {
+            Account(offset, buffer.Length);
+
+            // Read under the same lock as the accounting: one FileStream has one cursor, and the
+            // driver issues these concurrently.
+            _file.Seek(offset, SeekOrigin.Begin);
+            _file.ReadExactly(buffer.Span);
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Charges a read to the counters: every block it touches that is not already resident becomes
+    /// part of a request, and runs of adjacent new blocks are charged as one.
+    /// </summary>
+    private void Account(long offset, int length)
+    {
+        var firstBlock = offset / _blockSize;
+        var lastBlock = (offset + length - 1) / _blockSize;
+
+        var runLength = 0L;
+
+        for (var block = firstBlock; block <= lastBlock; block++)
+        {
+            if (_resident.Add(block))
+            {
+                runLength++;
+                continue;
+            }
+
+            // A resident block breaks the run: a client already holding it would not re-request it,
+            // so what follows is a separate request.
+            CloseRun(block - runLength, runLength);
+            runLength = 0;
+        }
+
+        CloseRun(lastBlock + 1 - runLength, runLength);
+    }
+
+    private void CloseRun(long firstBlock, long blockCount)
+    {
+        if (blockCount == 0)
+            return;
+
+        Interlocked.Increment(ref _requests);
+
+        // Clipped to the file, so the final partial block is not counted as a whole one.
+        var start = firstBlock * _blockSize;
+        var end = Math.Min(_file.Length, start + (blockCount * _blockSize));
+
+        Interlocked.Add(ref _bytesFetched, end - start);
+    }
+}

--- a/tests/PureHDF.Tests/TestUtils/TestUtils.cs
+++ b/tests/PureHDF.Tests/TestUtils/TestUtils.cs
@@ -9,7 +9,36 @@ namespace PureHDF.Tests;
 
 public partial class TestUtils
 {
-    public static string? DumpH5File(string filePath)
+    /// <summary>
+    /// What h5dump reported: its exit code, and both streams unmodified.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Failed" /> is the part worth asking for. h5dump prints its error stack to stderr and
+    /// still writes a partial tree to stdout, and <see cref="DumpH5File" /> strips that stack so the 134
+    /// fixture comparisons do not depend on the locally installed version - which also strips every
+    /// trace of failure, so a test asserting the dump does not contain "error" cannot fail. Ask this
+    /// instead when the question is whether the C library accepted the file at all.
+    /// </remarks>
+    public sealed record H5DumpResult(int ExitCode, string Stdout, string Stderr)
+    {
+        public bool Failed => ExitCode != 0 || Stderr.Contains("HDF5-DIAG:", StringComparison.Ordinal);
+
+        /// <summary>
+        /// The first few lines of the error stack, for a failure message worth reading.
+        /// </summary>
+        public string Diagnostics => string.Join(
+            Environment.NewLine,
+            Stderr
+                .Split('\n')
+                .Where(line => line.Contains("line ", StringComparison.Ordinal) || line.Contains("error", StringComparison.OrdinalIgnoreCase))
+                .Take(4)
+                .Select(line => line.Trim()));
+    }
+
+    /// <summary>
+    /// Runs h5dump and reports everything it said. Null when h5dump is not installed.
+    /// </summary>
+    public static H5DumpResult? RunH5Dump(string filePath)
     {
         // Read stdout and stderr concurrently on background tasks to
         // avoid deadlock if h5dump writes more than ~64 KB to stderr before
@@ -27,7 +56,18 @@ public partial class TestUtils
             }
         };
 
-        h5dumpProcess.Start();
+        try
+        {
+            h5dumpProcess.Start();
+        }
+
+        // Not installed. Reported as null rather than thrown, so that a Skip.If on it actually skips:
+        // these tests are about what the C library makes of a file, and there is nothing to learn
+        // without the C library.
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return null;
+        }
 
         var stdoutTask = Task.Run(() => h5dumpProcess.StandardOutput.ReadToEnd());
         var stderrTask = Task.Run(() => h5dumpProcess.StandardError.ReadToEnd());
@@ -45,27 +85,39 @@ public partial class TestUtils
                 $"h5dump did not exit within {timeoutMs} ms for '{filePath}'.");
         }
 
-        var stdoutStr = stdoutTask.GetAwaiter().GetResult().TrimEnd('\r', '\n');
-        var stderrStr = stderrTask.GetAwaiter().GetResult().TrimEnd('\r', '\n');
+        return new H5DumpResult(
+            ExitCode: h5dumpProcess.ExitCode,
+            Stdout: stdoutTask.GetAwaiter().GetResult().TrimEnd('\r', '\n'),
+            Stderr: stderrTask.GetAwaiter().GetResult().TrimEnd('\r', '\n'));
+    }
+
+    public static string? DumpH5File(string filePath)
+    {
+        var result = RunH5Dump(filePath);
+
+        if (result is null)
+            return null;
+
+        var stdoutStr = result.Stdout;
+        var stderrStr = result.Stderr;
+
         if (stdoutStr.Length == 0)
         {
             throw new InvalidOperationException(
-                $"h5dump produced no stdout for '{filePath}' (exit code {h5dumpProcess.ExitCode}). " +
+                $"h5dump produced no stdout for '{filePath}' (exit code {result.ExitCode}). " +
                 $"stderr:{Environment.NewLine}{stderrStr}");
         }
 
         var dump = stderrStr.Length > 0
             ? stdoutStr + Environment.NewLine + stderrStr
             : stdoutStr;
-			
+
         // Strip h5dump's trailing HDF5-DIAG error stack so the comparison
-        // doesn't depend on the locally-installed h5dump version. 
-        if (dump is not null)
-        {
-            var diagIdx = dump.IndexOf("HDF5-DIAG:", StringComparison.Ordinal);
-            if (diagIdx >= 0)
-                dump = dump[..diagIdx].TrimEnd('\r', '\n');
-        }
+        // doesn't depend on the locally-installed h5dump version.
+        var diagIdx = dump.IndexOf("HDF5-DIAG:", StringComparison.Ordinal);
+
+        if (diagIdx >= 0)
+            dump = dump[..diagIdx].TrimEnd('\r', '\n');
 
         return dump;
     }

--- a/tests/PureHDF.Tests/Writing/EndOfFileAddressTests.cs
+++ b/tests/PureHDF.Tests/Writing/EndOfFileAddressTests.cs
@@ -93,13 +93,15 @@ public class EndOfFileAddressTests(ITestOutputHelper output)
 
             // The C library is stricter than PureHDF's own reader here - it validates a contiguous
             // dataset's extent against the end of the file, which is exactly the check being satisfied.
-            var dump = TestUtils.DumpH5File(filePath);
+            var result = TestUtils.RunH5Dump(filePath);
 
-            Skip.If(dump is null, "h5dump is not available.");
+            Skip.If(result is null, "h5dump is not available.");
 
-            Assert.DoesNotContain("corruption", dump, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("error", dump, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("never-written", dump);
+            // The exit code and the raw error stream, not DumpH5File's output: that strips the error
+            // stack, so a test asserting the dump does not contain "corruption" passes on a file h5dump
+            // called corrupt.
+            Assert.False(result!.Failed, $"h5dump rejected the file:{Environment.NewLine}{result.Diagnostics}");
+            Assert.Contains("never-written", result.Stdout);
         }
 
         finally

--- a/tests/PureHDF.Tests/Writing/EndOfFileAddressTests.cs
+++ b/tests/PureHDF.Tests/Writing/EndOfFileAddressTests.cs
@@ -1,0 +1,93 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PureHDF.Tests.Writing;
+
+/// <summary>
+/// The file has to be as long as the addresses inside it claim, whatever was actually written.
+/// </summary>
+/// <remarks>
+/// An address can be referenced without ever being written to. A dataset created through
+/// <see cref="H5File.BeginWrite(string, H5WriteOptions?)" /> has its payload allocated and named by its
+/// layout message as soon as the structure is written, so a caller who never gets round to writing the
+/// data leaves a region that everything points at and nothing has touched.
+/// <para>
+/// Whether that shows up as a broken file is decided by the placement, which is what makes it worth a
+/// test of its own. An interleaved file tends to survive by accident: metadata is allocated after the
+/// payload, and writing it extends the stream over the gap. A front-loaded file serves metadata from a
+/// region at the front, so nothing extends the stream and it ends before the payload the layout points
+/// at - which the HDF5 C library reports as "invalid dataset size, likely file corruption" rather than
+/// as a short file.
+/// </para>
+/// </remarks>
+public class EndOfFileAddressTests(ITestOutputHelper output)
+{
+    private const int ElementCount = 100_000;
+    private const long PayloadBytes = ElementCount * sizeof(double);
+
+    [SkippableTheory]
+    [InlineData(H5MetadataPlacement.Interleaved)]
+    [InlineData(H5MetadataPlacement.Aggregated)]
+    [InlineData(H5MetadataPlacement.FrontLoaded)]
+    public void AnUnwrittenDeferredPayloadIsStillCoveredByTheFile(H5MetadataPlacement placement)
+    {
+        // Arrange - a dataset whose payload is allocated and referenced, and which is then never
+        // written. Compact layout is off so the payload cannot end up inside the object header.
+        var neverWritten = new H5Dataset<double[]>(fileDims: [ElementCount]);
+
+        var file = new H5File
+        {
+            ["written"] = new H5Dataset(Enumerable.Range(0, 64).ToArray()),
+            ["never-written"] = neverWritten
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            // Act
+            using (var writer = file.BeginWrite(filePath, new H5WriteOptions
+            {
+                PreferCompactDatasetLayout = false,
+                MetadataPlacement = placement
+            }))
+            {
+                // Deliberately no write: the point is the payload nobody fills.
+            }
+
+            var size = new FileInfo(filePath).Length;
+
+            output.WriteLine($"{placement,-12} file {size,10:N0} bytes, payload alone {PayloadBytes,10:N0}");
+
+            // Assert - checkable without any external tool: the file cannot be shorter than a region
+            // its own layout message points at.
+            Assert.True(
+                size > PayloadBytes,
+                $"{placement} produced {size:N0} bytes for a file referencing {PayloadBytes:N0} bytes of "
+                + $"payload, so the end-of-file address does not cover what the layout points at.");
+
+            // And PureHDF must still see the dataset it declared.
+            using (var root = H5File.OpenRead(filePath))
+            {
+                Assert.Equal((ulong)ElementCount, root.Dataset("never-written").Space.Dimensions[0]);
+                Assert.Equal(Enumerable.Range(0, 64).ToArray(), root.Dataset("written").Read<int[]>());
+            }
+
+            // The C library is stricter than PureHDF's own reader here - it validates a contiguous
+            // dataset's extent against the end of the file, which is exactly the check being satisfied.
+            var dump = TestUtils.DumpH5File(filePath);
+
+            Skip.If(dump is null, "h5dump is not available.");
+
+            Assert.DoesNotContain("corruption", dump, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("error", dump, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("never-written", dump);
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+}

--- a/tests/PureHDF.Tests/Writing/EndOfFileAddressTests.cs
+++ b/tests/PureHDF.Tests/Writing/EndOfFileAddressTests.cs
@@ -25,11 +25,27 @@ public class EndOfFileAddressTests(ITestOutputHelper output)
     private const int ElementCount = 100_000;
     private const long PayloadBytes = ElementCount * sizeof(double);
 
+    /// <remarks>
+    /// Run with and without a user block, because the two are counted from different places: the
+    /// allocator counts from the superblock, the stream from the start of the file, and a user block puts
+    /// those a <see cref="H5WriteOptions.UserBlockSize" /> apart. Comparing them untranslated makes the
+    /// file look long enough already and skips the extension, which is invisible until a user block is
+    /// in play - so the zero case cannot stand in for the nonzero one.
+    /// <para>
+    /// 512 rather than something larger because that is the only user block size this library round-trips
+    /// today: the superblock search in <c>NativeFile.InternalOpenAsync</c> doubles its step while seeking
+    /// relatively, so it probes 512, 1536, 3584 rather than the 512, 1024, 2048 the format specifies, and
+    /// only 512 lands. That is a reader bug of its own and nothing to do with placement.
+    /// </para>
+    /// </remarks>
     [SkippableTheory]
-    [InlineData(H5MetadataPlacement.Interleaved)]
-    [InlineData(H5MetadataPlacement.Aggregated)]
-    [InlineData(H5MetadataPlacement.FrontLoaded)]
-    public void AnUnwrittenDeferredPayloadIsStillCoveredByTheFile(H5MetadataPlacement placement)
+    [InlineData(H5MetadataPlacement.Interleaved, 0UL)]
+    [InlineData(H5MetadataPlacement.Aggregated, 0UL)]
+    [InlineData(H5MetadataPlacement.FrontLoaded, 0UL)]
+    [InlineData(H5MetadataPlacement.Interleaved, 512UL)]
+    [InlineData(H5MetadataPlacement.Aggregated, 512UL)]
+    [InlineData(H5MetadataPlacement.FrontLoaded, 512UL)]
+    public void AnUnwrittenDeferredPayloadIsStillCoveredByTheFile(H5MetadataPlacement placement, ulong userBlockSize)
     {
         // Arrange - a dataset whose payload is allocated and referenced, and which is then never
         // written. Compact layout is off so the payload cannot end up inside the object header.
@@ -49,7 +65,8 @@ public class EndOfFileAddressTests(ITestOutputHelper output)
             using (var writer = file.BeginWrite(filePath, new H5WriteOptions
             {
                 PreferCompactDatasetLayout = false,
-                MetadataPlacement = placement
+                MetadataPlacement = placement,
+                UserBlockSize = userBlockSize
             }))
             {
                 // Deliberately no write: the point is the payload nobody fills.
@@ -57,14 +74,15 @@ public class EndOfFileAddressTests(ITestOutputHelper output)
 
             var size = new FileInfo(filePath).Length;
 
-            output.WriteLine($"{placement,-12} file {size,10:N0} bytes, payload alone {PayloadBytes,10:N0}");
+            output.WriteLine($"{placement,-12} user block {userBlockSize,5}, file {size,10:N0} bytes, payload alone {PayloadBytes,10:N0}");
 
             // Assert - checkable without any external tool: the file cannot be shorter than a region
             // its own layout message points at.
             Assert.True(
-                size > PayloadBytes,
-                $"{placement} produced {size:N0} bytes for a file referencing {PayloadBytes:N0} bytes of "
-                + $"payload, so the end-of-file address does not cover what the layout points at.");
+                size > PayloadBytes + (long)userBlockSize,
+                $"{placement} with a {userBlockSize}-byte user block produced {size:N0} bytes for a file "
+                + $"referencing {PayloadBytes:N0} bytes of payload, so the end-of-file address does not "
+                + $"cover what the layout points at.");
 
             // And PureHDF must still see the dataset it declared.
             using (var root = H5File.OpenRead(filePath))

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -401,6 +401,91 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     }
 
     /// <summary>
+    /// What a deferred write costs the sizing pass, which can only be what the values decide.
+    /// </summary>
+    /// <remarks>
+    /// The pass runs before the caller has written anything through the writer, so the question is which
+    /// metadata it can still account for. A chunk index it can: its size follows from the chunk count,
+    /// and that follows from the dimensions, which are fixed when the dataset is declared -
+    /// <c>WriteChunkInfos</c> is sized to <c>TotalChunkCount</c> in <c>H5D_Chunk4.Initialize</c>, and
+    /// writing data later fills entries in an array whose length was settled then. Global heap space it
+    /// cannot: how much a variable-length value needs follows from the value.
+    /// <para>
+    /// So the shortfall is zero for fixed-size deferred data and nonzero only for variable-length, which
+    /// is why <see cref="H5WriteOptions.MetadataReservation" /> is worth setting for the latter and
+    /// nothing for the former. Asserted rather than reasoned, because the distinction is the entire
+    /// guidance given for deferred writes.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void OnlyVariableLengthDeferredDataOutrunsTheSizingPass()
+    {
+        var options = new H5WriteOptions
+        {
+            PreferCompactDatasetLayout = false,
+            MetadataPlacement = H5MetadataPlacement.Interleaved
+        };
+
+        long Shortfall<T>(string label, Func<H5Dataset<T>> makeDataset, T data)
+        {
+            var measured = H5NativeWriter.MeasureMetadataSize(
+                new H5File { ["d"] = makeDataset() }, options);
+
+            var dataset = makeDataset();
+            var filePath = Path.GetTempFileName();
+
+            try
+            {
+                var writer = new H5File { ["d"] = dataset }.BeginWrite(filePath, options);
+                writer.Write(dataset, data);
+                writer.Dispose();
+
+                var allocated = writer.Context.FreeSpaceManager.MetadataAllocated;
+
+                output.WriteLine($"{label,-38} measured {measured,9:N0}   allocated {allocated,9:N0}   shortfall {allocated - measured,9:N0}");
+
+                return allocated - measured;
+            }
+
+            finally
+            {
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+            }
+        }
+
+        var ints = Enumerable.Range(0, 1 << 16).ToArray();
+
+        var filtered = Shortfall(
+            "filtered chunked int (fixed array)",
+            () => new H5Dataset<int[]>(fileDims: [(ulong)ints.Length], chunks: [4096], datasetCreation: new(Filters: [DeflateFilter.Id])),
+            ints);
+
+        var unfiltered = Shortfall(
+            "unfiltered chunked int (implicit index)",
+            () => new H5Dataset<int[]>(fileDims: [(ulong)ints.Length], chunks: [4096]),
+            ints);
+
+        var strings = Enumerable.Range(0, 2_000).Select(i => new string('x', 120) + i).ToArray();
+
+        var variableLength = Shortfall(
+            "contiguous strings (global heap)",
+            () => new H5Dataset<string[]>(fileDims: [(ulong)strings.Length]),
+            strings);
+
+        // A chunk index is fully accounted for, however the chunks are indexed.
+        Assert.Equal(0, filtered);
+        Assert.Equal(0, unfiltered);
+
+        // Variable-length data is not, and by an amount worth reserving against rather than a rounding
+        // error - here 288 kB of global heap the pass had no way to see.
+        Assert.True(
+            variableLength > 200_000,
+            $"variable-length deferred data fell short by only {variableLength:N0} bytes, so this no "
+            + $"longer demonstrates the case MetadataReservation exists for.");
+    }
+
+    /// <summary>
     /// A small file must not pay a whole metadata block.
     /// </summary>
     /// <remarks>

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -41,8 +41,9 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         PreferCompactDatasetLayout = false,
         MetadataPlacement = placement,
 
-        // Scaled to these files. The waste is bounded by the block size, so on a 16 MB file an 8 MB
-        // default block would cost 50% while on the 620 MB file it costs 1.3%.
+        // Lowered from the 8 MB default only to keep the ceiling in view on files this size. Blocks
+        // double up to the ceiling rather than starting at it, so the default would not have inflated
+        // these files either - it would simply never have been reached.
         MetadataBlockSize = 1024 * 1024,
 
         // Deliberately generous. h5stat reports 522,088 bytes of "File metadata" for these files,
@@ -397,6 +398,68 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         output.WriteLine($"{label,-24} measured {measured,10:N0}   allocated {allocated,10:N0}");
 
         Assert.Equal(allocated, measured);
+    }
+
+    /// <summary>
+    /// A small file must not pay a whole metadata block.
+    /// </summary>
+    /// <remarks>
+    /// A block is claimed in full, so a block of fixed size is a floor on file size rather than a
+    /// proportional cost: at the 8 MB default, the 33 kB of metadata this file needs produced an 8.4 MB
+    /// file - 205 times the interleaved layout. Blocks therefore start small and double, which bounds
+    /// what is claimed at roughly twice what is used.
+    /// <para>
+    /// Deferred variable-length data is the case that provokes it hardest, and under every placement:
+    /// aggregation opens its first block, and a front-loaded reservation cannot have measured the global
+    /// heap these strings need, so it exhausts and spills into a block too.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(H5MetadataPlacement.Aggregated)]
+    [InlineData(H5MetadataPlacement.FrontLoaded)]
+    public void ASmallFileDoesNotPayAWholeMetadataBlock(H5MetadataPlacement placement)
+    {
+        var strings = Enumerable.Range(0, 500).Select(i => $"deferred-{i}-" + new string('y', i % 61)).ToArray();
+
+        long Write(H5MetadataPlacement value)
+        {
+            var dataset = new H5Dataset<string[]>(fileDims: [(ulong)strings.Length]);
+            var file = new H5File { ["strings"] = dataset };
+            var filePath = Path.GetTempFileName();
+
+            try
+            {
+                using (var writer = file.BeginWrite(filePath, new H5WriteOptions
+                {
+                    PreferCompactDatasetLayout = false,
+                    MetadataPlacement = value
+
+                    // MetadataBlockSize deliberately left at its 8 MB default: the default is the trap.
+                }))
+                {
+                    writer.Write(dataset, strings);
+                }
+
+                return new FileInfo(filePath).Length;
+            }
+
+            finally
+            {
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+            }
+        }
+
+        var interleaved = Write(H5MetadataPlacement.Interleaved);
+        var clustered = Write(placement);
+
+        output.WriteLine($"interleaved {interleaved,10:N0} bytes   {placement,-12} {clustered,10:N0} bytes   {clustered / (double)interleaved,6:N2}x");
+
+        // A small multiple, not a small difference: some overhead is inherent to claiming space up
+        // front. What must not happen is a fixed block dwarfing the file, which was 205x here.
+        Assert.True(
+            clustered < interleaved * 4,
+            $"{placement} produced {clustered:N0} bytes against {interleaved:N0} interleaved, so a block is being claimed whole.");
     }
 
     /// <summary>

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -46,14 +46,14 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         // these files either - it would simply never have been reached.
         MetadataBlockSize = 1024 * 1024,
 
-        // Deliberately generous. h5stat reports 522,088 bytes of "File metadata" for these files,
-        // but the ALLOCATED footprint is larger than that figure: global heap collections are
-        // allocated at a 4 kB minimum each and mostly left partly empty, which h5stat counts as
-        // unaccounted space rather than metadata. So 1 MB against a 522 kB report does not cover these
-        // files: the shortfall spills into a second region, which is the graceful path but costs the
-        // locality this is measuring. Size a reservation against measured file growth, not against the
-        // metadata line.
-        MetadataReservation = 3 * 1024 * 1024
+        // An explicit reservation, so these files exercise the path that skips the sizing pass. 1 MB
+        // against a measured need of 878,158 bytes, which covers it with room to spare - and the room
+        // is the point of the setting rather than a flaw in it: an explicit reservation abandons its
+        // unused tail, which is the price of not measuring. Size one against measured file growth
+        // rather than against h5stat's "File metadata" line, which reports 522,088 bytes here: global
+        // heap collections are allocated at a 4 kB minimum each and mostly left partly empty, and
+        // h5stat counts that as unaccounted space rather than as metadata.
+        MetadataReservation = 1024 * 1024
     };
 
     private static byte[] Write(Func<int, string> hint, int payloadPerGroup, H5WriteOptions? options = null)
@@ -255,8 +255,8 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// With no reservation given, the writer measures the file rather than estimating it - so the
-    /// reservation should be tight enough to cost about what aggregation costs, not multiples of it.
+    /// With no reservation given, the writer measures the file rather than estimating it - and a
+    /// measurement is exact, so front loading costs nothing at all rather than a little.
     /// </summary>
     /// <remarks>
     /// This is the assertion that pins the reservation to a measurement rather than to a model of the
@@ -266,7 +266,7 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     /// encoder and the same allocator.
     /// </remarks>
     [Fact]
-    public void AutoSizedFrontLoadingCostsAboutWhatAggregationCosts()
+    public void AutoSizedFrontLoadingCostsNothing()
     {
         const int slotSize = 1024 * 1024;
 
@@ -291,10 +291,50 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         // Locality: the whole point.
         Assert.True(after * 2 < afterTotal, $"structure touched {after} of {afterTotal} slots.");
 
-        // Size: a measured reservation is exact, so the only waste is the fixed slack the writer adds
-        // to keep the final allocation from spilling - a constant, not a fraction of the file. That
-        // makes this cheaper than aggregation, which pays for a whole unused block.
-        Assert.True(overhead < 0.005, $"auto-sized front loading cost {overhead:P2}, expected under 0.5%.");
+        // Size: a measured reservation is the exact number of bytes that will be served from it, so this
+        // costs nothing at all rather than a little. Asserted as equality, because "close enough" is what
+        // hid twelve kilobytes of slack that no test objected to.
+        Assert.Equal(interleaved.Length, autoSized.Length);
+        Assert.Equal(0, overhead);
+
+        // One region, nothing abandoned: the measurement was neither short (which spills into a second
+        // region and loses the locality) nor long (which pays for a tail nothing uses). This is the
+        // assertion that makes the two failure modes visible - MetadataRegionsOpened exists to report
+        // exactly this and was checked nowhere.
+        var probe = new H5File();
+
+        for (int i = 0; i < GroupCount; i++)
+        {
+            var group = new H5Group
+            {
+                ["values"] = new H5Dataset(Enumerable.Range(i, 2_000).ToArray())
+            };
+
+            group.Attributes = new Dictionary<string, object> { ["Meta::TypeHint"] = _sharedHint };
+            probe[$"unit{i:D5}"] = group;
+        }
+
+        var probePath = Path.GetTempFileName();
+
+        try
+        {
+            var writer = probe.BeginWrite(probePath, new H5WriteOptions
+            {
+                PreferCompactDatasetLayout = false,
+                MetadataPlacement = H5MetadataPlacement.FrontLoaded
+            });
+
+            writer.Dispose();
+
+            Assert.Equal(1, writer.Context.FreeSpaceManager.MetadataRegionsOpened);
+            Assert.Equal(0, writer.Context.FreeSpaceManager.MetadataAbandoned);
+        }
+
+        finally
+        {
+            if (File.Exists(probePath))
+                File.Delete(probePath);
+        }
 
         // And it must still be a correct file.
         using var root = H5File.Open(new MemoryStream(autoSized), leaveOpen: true);
@@ -651,8 +691,11 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     {
         const int slotSize = 1024 * 1024;
 
-        var shared = Write(_ => _sharedHint, payloadPerGroup: 2_000);
-        var distinct = Write(TypeHint, payloadPerGroup: 2_000);
+        // Options() rather than the default: the class remark above explains why compact layout has to
+        // be off for these files to measure anything, and defaulting it on made this the one place that
+        // ignored that.
+        var shared = Write(_ => _sharedHint, payloadPerGroup: 2_000, Options());
+        var distinct = Write(TypeHint, payloadPerGroup: 2_000, Options());
 
         var (sharedTouched, sharedTotal) = SlotsTouched(shared, slotSize);
         var (distinctTouched, distinctTotal) = SlotsTouched(distinct, slotSize);

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -1,0 +1,458 @@
+using PureHDF.Filters;
+using PureHDF.VOL.Native;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PureHDF.Tests.Writing;
+
+/// <summary>
+/// Baseline measurements for the writer's metadata layout, so the effect of changing it is a number
+/// rather than an impression.
+/// </summary>
+/// <remarks>
+/// Shaped after a real 620 MB reporting file: many small groups, each carrying the same
+/// assembly-qualified type-hint string as an attribute. Kept small enough to run in the suite.
+/// </remarks>
+public class MetadataLayoutTests(ITestOutputHelper output)
+{
+    private const int GroupCount = 2_000;
+
+    // 146 characters, the length of the assembly-qualified type name the reporting library writes.
+    private const int HintLength = 146;
+
+    private static string TypeHint(int i) =>
+        $"Ranovus.Reporting.Model.Measurement{i:D6}, Ranovus.Reporting, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+            .PadRight(HintLength, '.')[..HintLength];
+
+    private static readonly string _sharedHint = TypeHint(0);
+
+    /// <summary>
+    /// Compact layout is off for every file here, and that is load-bearing rather than incidental.
+    /// </summary>
+    /// <remarks>
+    /// A compact dataset's payload is embedded in its object header - see the compact branch in
+    /// <c>DataLayoutMessage4.Writing</c>, which makes no allocation of its own - so for datasets under
+    /// 64 kB, payload IS metadata and there is nothing for a placement to separate. Left on, these
+    /// files would be almost entirely "metadata" and the measurement would say nothing. The real
+    /// reporting files are chunked and filtered, so they take the contiguous/chunked path modelled here.
+    /// </remarks>
+    private static H5WriteOptions Options(H5MetadataPlacement placement = H5MetadataPlacement.Interleaved) => new()
+    {
+        PreferCompactDatasetLayout = false,
+        MetadataPlacement = placement,
+
+        // Scaled to these files. The waste is bounded by the block size, so on a 16 MB file an 8 MB
+        // default block would cost 50% while on the 620 MB file it costs 1.3%.
+        MetadataBlockSize = 1024 * 1024,
+
+        // Deliberately generous. h5stat reports 522,088 bytes of "File metadata" for these files,
+        // but the ALLOCATED footprint is larger than that figure: global heap collections are
+        // allocated at a 4 kB minimum each and mostly left partly empty, which h5stat counts as
+        // unaccounted space rather than metadata. So 1 MB against a 522 kB report does not cover these
+        // files: the shortfall spills into a second region, which is the graceful path but costs the
+        // locality this is measuring. Size a reservation against measured file growth, not against the
+        // metadata line.
+        MetadataReservation = 3 * 1024 * 1024
+    };
+
+    private static byte[] Write(Func<int, string> hint, int payloadPerGroup, H5WriteOptions? options = null)
+    {
+        var root = new H5File();
+
+        for (int i = 0; i < GroupCount; i++)
+        {
+            var group = new H5Group
+            {
+                // A little raw data per group, so metadata and data genuinely interleave.
+                ["values"] = new H5Dataset(Enumerable.Range(i, payloadPerGroup).ToArray())
+            };
+
+            group.Attributes = new Dictionary<string, object>
+            {
+                ["Meta::TypeHint"] = hint(i)
+            };
+
+            root[$"unit{i:D5}"] = group;
+        }
+
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            root.Write(filePath, options);
+
+            return File.ReadAllBytes(filePath);
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
+    /// <summary>
+    /// How many 1 MiB slots a reader must fetch to see every byte of file structure.
+    /// </summary>
+    /// <remarks>
+    /// The proxy for structural locality: object header signatures ("OHDR") and global heap collections
+    /// ("GCOL") are located, then mapped onto fixed-size slots. Touching every slot means a
+    /// range-request reader downloads the whole file to read the structure.
+    /// </remarks>
+    private static (int Touched, int Total) SlotsTouched(byte[] bytes, int slotSize)
+    {
+        var slots = new HashSet<int>();
+
+        void Mark(byte[] signature)
+        {
+            for (int i = 0; i + signature.Length <= bytes.Length; i++)
+            {
+                var match = true;
+
+                for (int j = 0; j < signature.Length; j++)
+                {
+                    if (bytes[i + j] != signature[j])
+                    {
+                        match = false;
+                        break;
+                    }
+                }
+
+                if (match)
+                    slots.Add(i / slotSize);
+            }
+        }
+
+        Mark("OHDR"u8.ToArray());
+        Mark("GCOL"u8.ToArray());
+
+        return (slots.Count, (bytes.Length + slotSize - 1) / slotSize);
+    }
+
+    /// <summary>
+    /// The point of the whole exercise: structure must stop touching every range of the file.
+    /// </summary>
+    /// <remarks>
+    /// Asserts a ratio rather than absolute slot counts, so it keeps its meaning if the writer's
+    /// encoding changes size. Each placement is also read back in full, because a layout that loses
+    /// locality is a disappointment while a layout that loses data is a catastrophe - and the two
+    /// failures look identical from a slot count.
+    /// </remarks>
+    [Theory]
+    [InlineData(H5MetadataPlacement.Aggregated)]
+    [InlineData(H5MetadataPlacement.FrontLoaded)]
+    public void PlacementClustersStructure(H5MetadataPlacement placement)
+    {
+        const int slotSize = 1024 * 1024;
+
+        var interleaved = Write(_ => _sharedHint, payloadPerGroup: 2_000, Options());
+        var clustered = Write(_ => _sharedHint, payloadPerGroup: 2_000, Options(placement));
+
+        var (before, beforeTotal) = SlotsTouched(interleaved, slotSize);
+        var (after, afterTotal) = SlotsTouched(clustered, slotSize);
+
+        output.WriteLine($"interleaved: {interleaved.Length,12:N0} bytes, structure in {before}/{beforeTotal} slots");
+        output.WriteLine($"{placement,-12}: {clustered.Length,12:N0} bytes, structure in {after}/{afterTotal} slots");
+        output.WriteLine($"file size cost: {(clustered.Length - interleaved.Length) / (double)interleaved.Length,8:P2}");
+
+        // Interleaved is expected to touch everything - that is the defect being fixed. If it ever
+        // stops doing so, this comparison has quietly become meaningless.
+        Assert.Equal(beforeTotal, before);
+
+        // Structure should fit in well under half the file's ranges.
+        Assert.True(
+            after * 2 < afterTotal,
+            $"{placement} touched {after} of {afterTotal} slots, expected fewer than half.");
+
+        // Every group must still read back correctly, attribute included.
+        using var root = H5File.Open(new MemoryStream(clustered), leaveOpen: true);
+
+        for (int i = 0; i < GroupCount; i += 250)
+        {
+            var group = root.Group($"unit{i:D5}");
+
+            Assert.Equal(_sharedHint, group.Attribute("Meta::TypeHint").Read<string>());
+            Assert.Equal(Enumerable.Range(i, 2_000).ToArray(), group.Dataset("values").Read<int[]>());
+        }
+    }
+
+    /// <summary>
+    /// The HDF5 C library must accept every placement, not just PureHDF's own reader.
+    /// </summary>
+    /// <remarks>
+    /// The layouts here are unusual in two ways the format permits but nothing else in this suite
+    /// exercises: structure sits before payload rather than beside it, and a reserved region can leave a
+    /// hole that nothing points into while the declared end-of-file address still covers it. Reading the
+    /// file back with PureHDF cannot catch a disagreement between the two implementations about either,
+    /// so this shells out to h5dump - the same tool the writer's dump fixtures use.
+    /// </remarks>
+    [SkippableTheory]
+    [InlineData(H5MetadataPlacement.Interleaved)]
+    [InlineData(H5MetadataPlacement.Aggregated)]
+    [InlineData(H5MetadataPlacement.FrontLoaded)]
+    public void TheCLibraryReadsEveryPlacement(H5MetadataPlacement placement)
+    {
+        // Arrange - small, because h5dump prints every value it finds.
+        var root = new H5File
+        {
+            ["group"] = new H5Group
+            {
+                ["values"] = new H5Dataset(Enumerable.Range(0, 64).ToArray()),
+                ["Meta::TypeHint"] = _sharedHint
+            }
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            root.Write(filePath, Options(placement));
+
+            // Act
+            var dump = TestUtils.DumpH5File(filePath);
+
+            Skip.If(dump is null, "h5dump is not available.");
+
+            // Assert - it parsed the file and found the contents, rather than reporting a bad superblock
+            // or a truncated file.
+            Assert.DoesNotContain("error", dump, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("values", dump);
+            Assert.Contains("Meta::TypeHint", dump);
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
+    /// <summary>
+    /// Interleaving stays the default, so this feature costs nothing until it is asked for.
+    /// </summary>
+    /// <remarks>
+    /// The default decides the bytes of every file the writer produces, so it is asserted rather than
+    /// left to the property initializer. Defaulting to a placement would change those bytes for callers
+    /// who never asked for it, and the only ones who benefit are those reading over a high-latency link
+    /// - who know that about themselves and can say so.
+    /// </remarks>
+    [Fact]
+    public void InterleavedIsTheDefault()
+    {
+        Assert.Equal(H5MetadataPlacement.Interleaved, new H5WriteOptions().MetadataPlacement);
+        Assert.Equal(0, new H5WriteOptions().MetadataReservation);
+
+        var byDefault = Write(_ => _sharedHint, payloadPerGroup: 500, new H5WriteOptions
+        {
+            PreferCompactDatasetLayout = false
+        });
+
+        var (touched, total) = SlotsTouched(byDefault, 256 * 1024);
+
+        // The default really is the old layout: structure spread across every range of the file.
+        Assert.Equal(total, touched);
+    }
+
+    /// <summary>
+    /// With no reservation given, the writer measures the file rather than estimating it - so the
+    /// reservation should be tight enough to cost about what aggregation costs, not multiples of it.
+    /// </summary>
+    /// <remarks>
+    /// This is the assertion that pins the reservation to a measurement rather than to a model of the
+    /// object graph. Two things put such a model out by multiples: a chunk index's size scales with chunk
+    /// count rather than being constant, and global heap collections are allocated at a 4 kB minimum each
+    /// and left partly empty. Encoding against a discarding stream sees both, because it is the same
+    /// encoder and the same allocator.
+    /// </remarks>
+    [Fact]
+    public void AutoSizedFrontLoadingCostsAboutWhatAggregationCosts()
+    {
+        const int slotSize = 1024 * 1024;
+
+        var interleaved = Write(_ => _sharedHint, payloadPerGroup: 2_000, Options());
+
+        var autoSized = Write(_ => _sharedHint, payloadPerGroup: 2_000, new H5WriteOptions
+        {
+            PreferCompactDatasetLayout = false,
+            MetadataPlacement = H5MetadataPlacement.FrontLoaded
+
+            // MetadataReservation deliberately unset: this is the path under test.
+        });
+
+        var (before, beforeTotal) = SlotsTouched(interleaved, slotSize);
+        var (after, afterTotal) = SlotsTouched(autoSized, slotSize);
+        var overhead = (autoSized.Length - interleaved.Length) / (double)interleaved.Length;
+
+        output.WriteLine($"interleaved      : {interleaved.Length,12:N0} bytes, structure in {before}/{beforeTotal} slots");
+        output.WriteLine($"front-loaded auto: {autoSized.Length,12:N0} bytes, structure in {after}/{afterTotal} slots");
+        output.WriteLine($"file size cost   : {overhead,8:P2}");
+
+        // Locality: the whole point.
+        Assert.True(after * 2 < afterTotal, $"structure touched {after} of {afterTotal} slots.");
+
+        // Size: a measured reservation is exact, so the only waste is the fixed slack the writer adds
+        // to keep the final allocation from spilling - a constant, not a fraction of the file. That
+        // makes this cheaper than aggregation, which pays for a whole unused block.
+        Assert.True(overhead < 0.005, $"auto-sized front loading cost {overhead:P2}, expected under 0.5%.");
+
+        // And it must still be a correct file.
+        using var root = H5File.Open(new MemoryStream(autoSized), leaveOpen: true);
+
+        for (int i = 0; i < GroupCount; i += 250)
+        {
+            var group = root.Group($"unit{i:D5}");
+
+            Assert.Equal(_sharedHint, group.Attribute("Meta::TypeHint").Read<string>());
+            Assert.Equal(Enumerable.Range(i, 2_000).ToArray(), group.Dataset("values").Read<int[]>());
+        }
+    }
+
+
+    /// <summary>
+    /// Every shape the writer can produce, so the sizing pass can be trusted across all of them.
+    /// </summary>
+    public static TheoryData<string, Func<H5File>> Shapes => new()
+    {
+        { "contiguous int", () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 4096).ToArray()) } },
+        { "compact int", () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 64).ToArray()) } },
+        { "unfiltered chunked int", () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 1 << 16).ToArray(), chunks: [4096]) } },
+        { "filtered chunked int", () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 1 << 16).ToArray(), chunks: [4096], datasetCreation: new(Filters: [DeflateFilter.Id])) } },
+        { "filtered single chunk", () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 4096).ToArray(), chunks: [4096], datasetCreation: new(Filters: [DeflateFilter.Id])) } },
+        { "variable-length strings", () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 500).Select(i => new string('x', 120) + i).ToArray()) } },
+        { "nullable ints", () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 500).Select(i => (int?)i).ToArray()) } },
+        { "string attribute", () => new H5File { ["g"] = new H5Group { Attributes = new Dictionary<string, object> { ["hint"] = _sharedHint } } } },
+        { "object reference", () => Referencing() },
+        { "many groups", () => ManyGroups() }
+    };
+
+    private static H5File Referencing()
+    {
+        var target = new H5Group { ["values"] = new H5Dataset(Enumerable.Range(0, 4096).ToArray()) };
+
+        return new H5File
+        {
+            ["target"] = target,
+            ["pointer"] = new H5Dataset(new[] { new H5ObjectReference(target) })
+        };
+    }
+
+    private static H5File ManyGroups()
+    {
+        var root = new H5File();
+
+        for (int i = 0; i < 200; i++)
+        {
+            root[$"unit{i:D4}"] = new H5Group
+            {
+                ["values"] = new H5Dataset(Enumerable.Range(i, 2_000).ToArray()),
+                Attributes = new Dictionary<string, object> { ["hint"] = _sharedHint }
+            };
+        }
+
+        return root;
+    }
+
+    private static long MetadataAllocatedByAWrite(H5File file, H5WriteOptions options)
+    {
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            var writer = file.BeginWrite(filePath, options);
+            writer.Dispose();
+
+            return writer.Context.FreeSpaceManager.MetadataAllocated;
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
+    /// <summary>
+    /// The sizing pass must report the same total a real write allocates - exactly, for every shape.
+    /// </summary>
+    /// <remarks>
+    /// The load-bearing test for front loading, and the one that lets the pass take shortcuts. It takes
+    /// two: it does not compress, and for fixed-size elements it does not touch the data at all. Both
+    /// rest on the same claim - that no metadata size depends on a value - and this asserts that claim
+    /// per shape rather than arguing it. An inequality would not do: a pass that over-counts wastes the
+    /// reservation's tail and one that under-counts spills, so the number has to be the number.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(Shapes))]
+    public void TheSizingPassMeasuresExactlyWhatAWriteAllocates(string label, Func<H5File> makeFile)
+    {
+        var options = new H5WriteOptions
+        {
+            PreferCompactDatasetLayout = false,
+            MetadataPlacement = H5MetadataPlacement.Interleaved
+        };
+
+        var measured = H5NativeWriter.MeasureMetadataSize(makeFile(), options);
+        var allocated = MetadataAllocatedByAWrite(makeFile(), options);
+
+        output.WriteLine($"{label,-24} measured {measured,10:N0}   allocated {allocated,10:N0}");
+
+        Assert.Equal(allocated, measured);
+    }
+
+    /// <summary>
+    /// An unfiltered chunked dataset's payload is payload, however the format reaches it.
+    /// </summary>
+    /// <remarks>
+    /// Such a dataset is indexed implicitly, which means it has no index structure at all: the chunks
+    /// sit contiguously from the address in the layout message, and a chunk's address is arithmetic on
+    /// it. So what the layout allocates there is the entire payload. Counting it as structure front-loads
+    /// the payload along with everything else and dissolves the separation this feature exists to make -
+    /// silently, because a reader still finds the file correct and the size never changes.
+    /// </remarks>
+    [Fact]
+    public void AnImplicitChunkIndexIsPayloadRatherThanStructure()
+    {
+        const int elementCount = 1 << 16;
+        const long payload = elementCount * sizeof(int);
+
+        var file = new H5File
+        {
+            ["chunked"] = new H5Dataset(Enumerable.Range(0, elementCount).ToArray(), chunks: [4096])
+        };
+
+        var measured = H5NativeWriter.MeasureMetadataSize(file, new H5WriteOptions
+        {
+            PreferCompactDatasetLayout = false,
+            MetadataPlacement = H5MetadataPlacement.Interleaved
+        });
+
+        output.WriteLine($"payload {payload,10:N0} bytes, structure {measured,10:N0} bytes");
+
+        Assert.True(
+            measured < payload / 100,
+            $"structure measured {measured:N0} bytes against {payload:N0} bytes of payload, so the payload is being counted as structure.");
+    }
+
+
+    [Fact]
+    public void MeasureBaseline()
+    {
+        const int slotSize = 1024 * 1024;
+
+        var shared = Write(_ => _sharedHint, payloadPerGroup: 2_000);
+        var distinct = Write(TypeHint, payloadPerGroup: 2_000);
+
+        var (sharedTouched, sharedTotal) = SlotsTouched(shared, slotSize);
+        var (distinctTouched, distinctTotal) = SlotsTouched(distinct, slotSize);
+
+        output.WriteLine($"{GroupCount} groups, identical type hint : {shared.Length,12:N0} bytes, structure in {sharedTouched}/{sharedTotal} slots of 1 MiB");
+        output.WriteLine($"{GroupCount} groups, distinct type hints : {distinct.Length,12:N0} bytes, structure in {distinctTouched}/{distinctTotal} slots of 1 MiB");
+        output.WriteLine($"difference attributable to repeated string payload: {distinct.Length - shared.Length,12:N0} bytes");
+        output.WriteLine($"payload if every copy were stored: {(long)GroupCount * 146,12:N0} bytes");
+
+        // No assertion on the numbers - this test exists to report them. It asserts only that the
+        // files are readable, so it cannot silently measure garbage.
+        using var root = H5File.Open(new MemoryStream(shared), leaveOpen: true);
+        Assert.Equal(_sharedHint, root.Group("unit00000").Attribute("Meta::TypeHint").Read<string>());
+    }
+}

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -210,15 +210,16 @@ public class MetadataLayoutTests(ITestOutputHelper output)
             root.Write(filePath, Options(placement));
 
             // Act
-            var dump = TestUtils.DumpH5File(filePath);
+            var result = TestUtils.RunH5Dump(filePath);
 
-            Skip.If(dump is null, "h5dump is not available.");
+            Skip.If(result is null, "h5dump is not available.");
 
             // Assert - it parsed the file and found the contents, rather than reporting a bad superblock
-            // or a truncated file.
-            Assert.DoesNotContain("error", dump, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("values", dump);
-            Assert.Contains("Meta::TypeHint", dump);
+            // or a truncated file. Asked of the exit code and the raw error stream rather than of
+            // DumpH5File's output, which strips the error stack and so can never contain a complaint.
+            Assert.False(result!.Failed, $"h5dump rejected the file:{Environment.NewLine}{result.Diagnostics}");
+            Assert.Contains("values", result.Stdout);
+            Assert.Contains("Meta::TypeHint", result.Stdout);
         }
 
         finally
@@ -652,6 +653,57 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         // Anything other than equality means space is being claimed that nothing accounts for.
         Assert.True(growth > 0, "this fixture no longer abandons anything, so it proves nothing");
         Assert.Equal(growth, abandoned);
+    }
+
+    /// <summary>
+    /// Options that cannot mean anything are rejected rather than quietly ignored.
+    /// </summary>
+    /// <remarks>
+    /// A non-positive block size used to turn <see cref="H5MetadataPlacement.Aggregated" /> into
+    /// <see cref="H5MetadataPlacement.Interleaved" /> without a word: the block path is gated on a
+    /// positive size, so a caller asking for clustering got none and had nothing to tell them why.
+    /// Interleaved keeps ignoring the setting, because it genuinely does not use blocks.
+    /// </remarks>
+    [Theory]
+    [InlineData(H5MetadataPlacement.Aggregated, 0L, 0L)]
+    [InlineData(H5MetadataPlacement.Aggregated, -1L, 0L)]
+    [InlineData(H5MetadataPlacement.FrontLoaded, 0L, 0L)]
+    [InlineData(H5MetadataPlacement.FrontLoaded, 8 * 1024 * 1024L, -1L)]
+    [InlineData(H5MetadataPlacement.Interleaved, 8 * 1024 * 1024L, -1L)]
+    public void DegeneratePlacementOptionsAreRejected(
+        H5MetadataPlacement placement,
+        long blockSize,
+        long reservation)
+    {
+        var file = new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 64).ToArray()) };
+
+        Assert.ThrowsAny<Exception>(() => file.Write(new MemoryStream(), new H5WriteOptions
+        {
+            MetadataPlacement = placement,
+            MetadataBlockSize = blockSize,
+            MetadataReservation = reservation
+        }));
+    }
+
+    /// <summary>
+    /// A block size interleaving never consults is not an error.
+    /// </summary>
+    [Fact]
+    public void InterleavingIgnoresTheBlockSize()
+    {
+        var file = new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 64).ToArray()) };
+        var stream = new MemoryStream();
+
+        file.Write(stream, new H5WriteOptions
+        {
+            MetadataPlacement = H5MetadataPlacement.Interleaved,
+            MetadataBlockSize = 0
+        });
+
+        stream.Position = 0;
+
+        using var root = H5File.Open(stream, leaveOpen: true);
+        Assert.Equal(Enumerable.Range(0, 64).ToArray(), root.Dataset("d").Read<int[]>());
     }
 
     /// <summary>

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -463,6 +463,70 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     }
 
     /// <summary>
+    /// The abandoned figure has to account for the space the file actually grew by.
+    /// </summary>
+    /// <remarks>
+    /// A region is claimed in full and there is no free list, so file size over the interleaved layout
+    /// is exactly what was claimed and not used. That makes the two independently measurable, which is
+    /// the only reason the metric can be checked at all rather than merely reported: growth is observed
+    /// from outside, abandonment is reported from inside, and they have to agree.
+    /// <para>
+    /// Counting only regions already replaced does not agree. A region is replaced only when a request
+    /// does not fit it, so those remainders are small by construction - it reported 48 bytes against
+    /// 8 MB of growth - while the tail of the region left open is the part that is actually large.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(H5MetadataPlacement.Aggregated)]
+    [InlineData(H5MetadataPlacement.FrontLoaded)]
+    public void AbandonedSpaceAccountsForTheFileGrowth(H5MetadataPlacement placement)
+    {
+        var strings = Enumerable.Range(0, 500).Select(i => $"deferred-{i}-" + new string('y', i % 61)).ToArray();
+
+        (long Size, long Abandoned) Write(H5MetadataPlacement value)
+        {
+            var dataset = new H5Dataset<string[]>(fileDims: [(ulong)strings.Length]);
+            var file = new H5File { ["strings"] = dataset };
+            var filePath = Path.GetTempFileName();
+
+            try
+            {
+                var writer = file.BeginWrite(filePath, new H5WriteOptions
+                {
+                    PreferCompactDatasetLayout = false,
+                    MetadataPlacement = value
+                });
+
+                writer.Write(dataset, strings);
+                writer.Dispose();
+
+                return (new FileInfo(filePath).Length, writer.Context.FreeSpaceManager.MetadataAbandoned);
+            }
+
+            finally
+            {
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+            }
+        }
+
+        var (interleavedSize, interleavedAbandoned) = Write(H5MetadataPlacement.Interleaved);
+        var (size, abandoned) = Write(placement);
+        var growth = size - interleavedSize;
+
+        output.WriteLine($"{placement,-12} grew {growth,10:N0} bytes, reports {abandoned,10:N0} abandoned");
+
+        // Interleaving claims no region, so it can abandon nothing.
+        Assert.Equal(0, interleavedAbandoned);
+
+        // Exactly the growth, not approximately. Interleaving claims precisely what it uses, so the
+        // same content written with a region claims the same allocations plus whatever it abandoned -
+        // and the front-loaded reservation's fixed slack is part of that, claimed and unused like the
+        // rest. Anything other than equality means space is being claimed that nothing accounts for.
+        Assert.Equal(growth, abandoned);
+    }
+
+    /// <summary>
     /// An unfiltered chunked dataset's payload is payload, however the format reaches it.
     /// </summary>
     /// <remarks>

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -441,24 +441,25 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// What a deferred write costs the sizing pass, which can only be what the values decide.
+    /// Nothing a deferred write does outruns the sizing pass.
     /// </summary>
     /// <remarks>
     /// The pass runs before the caller has written anything through the writer, so the question is which
-    /// metadata it can still account for. A chunk index it can: its size follows from the chunk count,
-    /// and that follows from the dimensions, which are fixed when the dataset is declared -
-    /// <c>WriteChunkInfos</c> is sized to <c>TotalChunkCount</c> in <c>H5D_Chunk4.Initialize</c>, and
-    /// writing data later fills entries in an array whose length was settled then. Global heap space it
-    /// cannot: how much a variable-length value needs follows from the value.
+    /// metadata it can still account for. All of it, as it turns out. A chunk index's size follows from
+    /// the chunk count, and that follows from the dimensions, which are fixed when the dataset is
+    /// declared - <c>WriteChunkInfos</c> is sized to <c>TotalChunkCount</c> in
+    /// <c>H5D_Chunk4.Initialize</c>, and writing data later fills entries in an array whose length was
+    /// settled then. And a variable-length value's global heap space is allocated as payload rather than
+    /// as structure, so however much of it a caller writes later, the metadata total does not move.
     /// <para>
-    /// So the shortfall is zero for fixed-size deferred data and nonzero only for variable-length, which
-    /// is why <see cref="H5WriteOptions.MetadataReservation" /> is worth setting for the latter and
-    /// nothing for the former. Asserted rather than reasoned, because the distinction is the entire
-    /// guidance given for deferred writes.
+    /// That is what makes <see cref="H5WriteOptions.MetadataReservation" /> unnecessary for a deferred
+    /// write rather than advisable for some of them. Asserted rather than reasoned, because it is the
+    /// entire guidance given for deferred writes - and the guidance said the opposite twice before this
+    /// test existed.
     /// </para>
     /// </remarks>
     [Fact]
-    public void OnlyVariableLengthDeferredDataOutrunsTheSizingPass()
+    public void NothingDeferredOutrunsTheSizingPass()
     {
         var options = new H5WriteOptions
         {
@@ -517,12 +518,9 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         Assert.Equal(0, filtered);
         Assert.Equal(0, unfiltered);
 
-        // Variable-length data is not, and by an amount worth reserving against rather than a rounding
-        // error - here 288 kB of global heap the pass had no way to see.
-        Assert.True(
-            variableLength > 200_000,
-            $"variable-length deferred data fell short by only {variableLength:N0} bytes, so this no "
-            + $"longer demonstrates the case MetadataReservation exists for.");
+        // And so is variable-length data, now that its heap collections are payload. This was 294,912
+        // bytes short while they counted as structure.
+        Assert.Equal(0, variableLength);
     }
 
     /// <summary>
@@ -602,9 +600,9 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     /// </para>
     /// </remarks>
     [Theory]
-    [InlineData(H5MetadataPlacement.Aggregated)]
-    [InlineData(H5MetadataPlacement.FrontLoaded)]
-    public void AbandonedSpaceAccountsForTheFileGrowth(H5MetadataPlacement placement)
+    [InlineData(H5MetadataPlacement.Aggregated, 0L)]
+    [InlineData(H5MetadataPlacement.FrontLoaded, 256 * 1024L)]
+    public void AbandonedSpaceAccountsForTheFileGrowth(H5MetadataPlacement placement, long reservation)
     {
         var strings = Enumerable.Range(0, 500).Select(i => $"deferred-{i}-" + new string('y', i % 61)).ToArray();
 
@@ -619,7 +617,12 @@ public class MetadataLayoutTests(ITestOutputHelper output)
                 var writer = file.BeginWrite(filePath, new H5WriteOptions
                 {
                     PreferCompactDatasetLayout = false,
-                    MetadataPlacement = value
+                    MetadataPlacement = value,
+
+                    // Explicit and deliberately generous for the front-loaded case. A measured
+                    // reservation now abandons nothing at all, so there would be no waste for the
+                    // metric to account for and the assertion below would hold for the wrong reason.
+                    MetadataReservation = reservation
                 });
 
                 writer.Write(dataset, strings);
@@ -645,10 +648,80 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         Assert.Equal(0, interleavedAbandoned);
 
         // Exactly the growth, not approximately. Interleaving claims precisely what it uses, so the
-        // same content written with a region claims the same allocations plus whatever it abandoned -
-        // and the front-loaded reservation's fixed slack is part of that, claimed and unused like the
-        // rest. Anything other than equality means space is being claimed that nothing accounts for.
+        // same content written with a region claims those same allocations plus whatever it abandoned.
+        // Anything other than equality means space is being claimed that nothing accounts for.
+        Assert.True(growth > 0, "this fixture no longer abandons anything, so it proves nothing");
         Assert.Equal(growth, abandoned);
+    }
+
+    /// <summary>
+    /// A dataset's variable-length values are its payload; an attribute's are structure.
+    /// </summary>
+    /// <remarks>
+    /// Both live on the global heap, so one classification for the whole heap has to be wrong for one of
+    /// them. Counting all of it as structure was: a dataset of variable-length strings with no attributes
+    /// at all measured 97% structure, so a front-loaded region swallowed the payload and there was
+    /// nothing left to separate - silently, since the file stays valid and the same size and only the
+    /// locality quietly stops materialising.
+    /// <para>
+    /// The distinction is the reader's, as everywhere else here: an attribute's value is read while
+    /// browsing a file, a dataset's elements only when reading that dataset.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ADatasetsVariableLengthValuesArePayloadAndAnAttributesAreStructure()
+    {
+        var options = new H5WriteOptions
+        {
+            PreferCompactDatasetLayout = false,
+            MetadataPlacement = H5MetadataPlacement.Interleaved
+        };
+
+        var strings = Enumerable.Range(0, 2_000).Select(i => new string('x', 500) + i).ToArray();
+
+        double StructureShare(string label, Func<H5File> makeFile)
+        {
+            var measured = H5NativeWriter.MeasureMetadataSize(makeFile(), options);
+            var filePath = Path.GetTempFileName();
+
+            try
+            {
+                makeFile().Write(filePath, options);
+
+                var size = new FileInfo(filePath).Length;
+                var share = measured / (double)size;
+
+                output.WriteLine($"{label,-38} structure {measured,10:N0} of {size,10:N0} = {share,7:P1}");
+
+                return share;
+            }
+
+            finally
+            {
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+            }
+        }
+
+        var datasetOnly = StructureShare(
+            "vlen strings as dataset, no attributes",
+            () => new H5File { ["d"] = new H5Dataset(strings) });
+
+        var jagged = StructureShare(
+            "jagged arrays as dataset, no attributes",
+            () => new H5File { ["d"] = new H5Dataset(Enumerable.Range(0, 2_000).Select(i => Enumerable.Range(0, 125).ToArray()).ToArray()) });
+
+        var attributeOnly = StructureShare(
+            "one large string as an attribute",
+            () => new H5File { ["g"] = new H5Group { Attributes = new Dictionary<string, object> { ["h"] = string.Join(",", strings.Take(200)) } } });
+
+        // A dataset's heap is payload: what remains as structure is the object headers and the
+        // superblock, a rounding error against a megabyte of strings. This was 97.3%.
+        Assert.True(datasetOnly < 0.01, $"a variable-length dataset measured {datasetOnly:P1} structure.");
+        Assert.True(jagged < 0.01, $"a jagged-array dataset measured {jagged:P1} structure.");
+
+        // An attribute's heap is structure, and an attributes-only file is therefore all structure.
+        Assert.True(attributeOnly > 0.99, $"an attribute-only file measured {attributeOnly:P1} structure.");
     }
 
     /// <summary>

--- a/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataLayoutTests.cs
@@ -591,7 +591,8 @@ public class MetadataLayoutTests(ITestOutputHelper output)
     /// </summary>
     /// <remarks>
     /// A region is claimed in full and there is no free list, so file size over the interleaved layout
-    /// is exactly what was claimed and not used. That makes the two independently measurable, which is
+    /// is exactly what was claimed and not used, across every region. That makes the two independently
+    /// measurable, which is
     /// the only reason the metric can be checked at all rather than merely reported: growth is observed
     /// from outside, abandonment is reported from inside, and they have to agree.
     /// <para>
@@ -629,7 +630,9 @@ public class MetadataLayoutTests(ITestOutputHelper output)
                 writer.Write(dataset, strings);
                 writer.Dispose();
 
-                return (new FileInfo(filePath).Length, writer.Context.FreeSpaceManager.MetadataAbandoned);
+                var fsm = writer.Context.FreeSpaceManager;
+
+                return (new FileInfo(filePath).Length, fsm.MetadataAbandoned + fsm.PayloadAbandoned);
             }
 
             finally
@@ -648,9 +651,11 @@ public class MetadataLayoutTests(ITestOutputHelper output)
         // Interleaving claims no region, so it can abandon nothing.
         Assert.Equal(0, interleavedAbandoned);
 
-        // Exactly the growth, not approximately. Interleaving claims precisely what it uses, so the
-        // same content written with a region claims those same allocations plus whatever it abandoned.
-        // Anything other than equality means space is being claimed that nothing accounts for.
+        // Exactly the growth, not approximately, and summed over both clustered regions: structure and
+        // deferred payload are gathered independently, so a file carrying a vlen dataset abandons a tail
+        // in each. Interleaving claims precisely what it uses, so the same content written with regions
+        // claims those same allocations plus whatever they abandoned. Anything other than equality means
+        // space is being claimed that nothing accounts for.
         Assert.True(growth > 0, "this fixture no longer abandons anything, so it proves nothing");
         Assert.Equal(growth, abandoned);
     }

--- a/tests/PureHDF.Tests/Writing/MetadataPlacementRoundTripTests.cs
+++ b/tests/PureHDF.Tests/Writing/MetadataPlacementRoundTripTests.cs
@@ -1,0 +1,123 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PureHDF.Tests.Writing;
+
+/// <summary>
+/// Every placement must produce a file that reads back, for the data types whose encoding allocates.
+/// </summary>
+/// <remarks>
+/// Variable-length data is what makes placement interesting and what makes it risky. Its global heap
+/// collections are metadata, so they move with the structure, and their size follows from the values
+/// rather than from the dataspace - which is the one thing a sizing pass cannot know in advance. So
+/// these are the writes where a region can be exhausted mid-file and the allocator has to fall back
+/// while addresses already encoded stay correct. A placement that loses locality is a disappointment;
+/// one that loses data is a catastrophe, and from a byte count the two look identical.
+/// </remarks>
+public class MetadataPlacementRoundTripTests(ITestOutputHelper output)
+{
+    private struct Mixed
+    {
+        public int Number;
+        public string Text;
+    }
+
+    private static H5WriteOptions Options(H5MetadataPlacement placement) => new()
+    {
+        PreferCompactDatasetLayout = false,
+        MetadataPlacement = placement
+    };
+
+    [Theory]
+    [InlineData(H5MetadataPlacement.Interleaved)]
+    [InlineData(H5MetadataPlacement.Aggregated)]
+    [InlineData(H5MetadataPlacement.FrontLoaded)]
+    public void VariableLengthDataSurvivesEveryPlacement(H5MetadataPlacement placement)
+    {
+        // Arrange - one dataset per path through the element encoder that touches the global heap.
+        var strings = Enumerable.Range(0, 500).Select(i => $"value-{i}-" + new string('x', i % 97)).ToArray();
+        var jagged = Enumerable.Range(0, 200).Select(i => Enumerable.Range(0, i % 13 + 1).ToArray()).ToArray();
+        var nullables = Enumerable.Range(0, 300).Select(i => i % 5 == 0 ? (int?)null : i).ToArray();
+        var mixed = Enumerable.Range(0, 100).Select(i => new Mixed { Number = i, Text = $"row-{i}" }).ToArray();
+        var hint = new string('h', 300);
+
+        var file = new H5File
+        {
+            ["strings"] = new H5Dataset(strings),
+            ["jagged"] = new H5Dataset(jagged),
+            ["nullables"] = new H5Dataset(nullables),
+            ["mixed"] = new H5Dataset(mixed),
+            Attributes = new Dictionary<string, object> { ["hint"] = hint }
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            // Act
+            file.Write(filePath, Options(placement));
+
+            output.WriteLine($"{placement,-12} {new FileInfo(filePath).Length,10:N0} bytes");
+
+            // Assert
+            using var root = H5File.OpenRead(filePath);
+
+            Assert.Equal(strings, root.Dataset("strings").Read<string[]>());
+            Assert.Equal(jagged, root.Dataset("jagged").Read<int[][]>());
+            Assert.Equal(nullables, root.Dataset("nullables").Read<int?[]>());
+            Assert.Equal(mixed, root.Dataset("mixed").Read<Mixed[]>());
+            Assert.Equal(hint, root.Attribute("hint").Read<string>());
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+
+    /// <summary>
+    /// The same, written after the fact - where the sizing pass could not have seen the values.
+    /// </summary>
+    /// <remarks>
+    /// The case a measured reservation cannot cover, so under a front-loaded placement this write is
+    /// guaranteed to exhaust its region and take the fallback path. It has to end in a correct file
+    /// regardless, which is the whole reason the fallback opens a new region rather than throwing.
+    /// </remarks>
+    [Theory]
+    [InlineData(H5MetadataPlacement.Interleaved)]
+    [InlineData(H5MetadataPlacement.Aggregated)]
+    [InlineData(H5MetadataPlacement.FrontLoaded)]
+    public void DeferredVariableLengthDataSurvivesEveryPlacement(H5MetadataPlacement placement)
+    {
+        // Arrange
+        var strings = Enumerable.Range(0, 500).Select(i => $"deferred-{i}-" + new string('y', i % 61)).ToArray();
+
+        var dataset = new H5Dataset<string[]>(fileDims: [(ulong)strings.Length]);
+        var file = new H5File { ["strings"] = dataset };
+
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            // Act
+            using (var writer = file.BeginWrite(filePath, Options(placement)))
+            {
+                writer.Write(dataset, strings);
+            }
+
+            output.WriteLine($"{placement,-12} {new FileInfo(filePath).Length,10:N0} bytes");
+
+            // Assert
+            using var root = H5File.OpenRead(filePath);
+
+            Assert.Equal(strings, root.Dataset("strings").Read<string[]>());
+        }
+
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
+}


### PR DESCRIPTION
Structure is currently allocated in encode order, so it ends up spread evenly through the file. A reader that fetches ranges rather than seeking freely therefore pays for the whole file to read the structure: on a 620 MB reporting file, walking the 8.2% of bytes that are structure touched 591 of 591 one-megabyte ranges.

`H5WriteOptions.MetadataPlacement` adds two alternatives to the layout the writer produces today, which stays the default:

| Placement | Allocation | Effect |
|---|---|---|
| `Interleaved` | in encode order | the default, and the layout the writer produces today, byte for byte |
| `Aggregated` | from blocks that double in size, forming a few clusters | needs no estimate of the total |
| `FrontLoaded` | from one region reserved at the front | a reader fetches all structure in one range |

`FrontLoaded` sizes its reservation by measuring, so callers do not have to — and because the measurement is exact, **it costs no file size at all**.

Measured in `RangeReadCostTests`, over a block-fetching stream that counts what an HTTP range client would have transferred (600 groups of deflated measurement series, 256 kB blocks):

```
interleaved    fetched 4,050,543 B of 4,050,543 B   100.0% of file   16 requests
aggregated     fetched   786,432 B of 4,052,705 B    19.4% of file    3 requests
front-loaded   fetched   262,144 B of 4,050,543 B     6.5% of file    1 request
```

And in `MetadataLayoutTests`, on 2,000 groups each with a contiguous dataset and a string attribute, at 1 MiB ranges:

```
interleaved       16,878,158 bytes   structure in 17/17 ranges
front-loaded      16,878,158 bytes   structure in  1/17 ranges
```

Same byte count, one range instead of seventeen.

### How it works

The writer allocates every address before writing and then seeks to it, so segregating regions needed no change to any encoding logic — only the allocator, plus classifying the allocation sites as structure or payload. Three of those are not what they look like:

- **An implicit chunk index is not an index.** The chunks sit contiguously from the address in the layout message and a chunk's address is arithmetic on it, so what is allocated there is the whole payload of an unfiltered chunked dataset.
- **The global heap serves both kinds.** An attribute's variable-length value is structure — it is what a viewer reads while browsing — while a dataset's own variable-length elements are payload. One classification for the whole heap has to be wrong for one of them, so the manager keeps a collection open per kind.
- **A compact dataset's payload lives inside its object header** and makes no allocation of its own, so for datasets under 64 kB payload *is* structure and there is nothing to separate. Files that lean on `PreferCompactDatasetLayout` see little from this.

The reservation is sized by a pass that encodes the file against a stream discarding everything and reads the metadata total off the allocator. It is exact rather than estimated because it is the same encoder and the same allocator, which is what lets it account for what an estimate cannot: a chunk index's size scales with chunk count, and global heap collections are allocated at a 4 kB minimum each and left partly empty. An earlier estimator missed both and over-reserved threefold, so it was removed rather than kept as a fallback.

The pass does not compress, and for fixed-size element types it does not touch the data at all — no selection walk, no chunk buffers, no byte copying. Best of seven runs on a 64 MB file, against a full write of the same file:

```
unfiltered    34.9 ms -> 1.3 ms    43% of a write -> 2%
filtered      29.4 ms -> 0.9 ms   2.6% of a write -> 0.1%
```

`MetadataLayoutTests.TheSizingPassMeasuresExactlyWhatAWriteAllocates` asserts per shape — contiguous, compact, chunked filtered and unfiltered, single-chunk, variable-length strings, `Nullable<T>`, attributes, object references, many groups — that the pass measures exactly what a write allocates. That equality is what both shortcuts rest on, and an inequality either way is a defect: over-counting wastes the reservation's tail, under-counting spills.

Set `MetadataReservation` to skip the pass. Nothing else requires it — including a deferred write through `BeginWrite`, since nothing a caller writes later changes how much structure the file has.

### Worth flagging

- **There is no free list**, so a region's unused remainder is abandoned rather than reclaimed. A measured reservation abandons nothing, so this is only a cost when you set `MetadataReservation` yourself, or when a reservation comes up short and spills into blocks — which loses locality for the remainder rather than failing.
- **Metadata blocks grow rather than being fixed.** A block is claimed in full, so a fixed size is a floor on file size: at the 8 MB default, 33 kB of metadata produced an 8.4 MB file. Blocks now start at 64 kB and double up to `MetadataBlockSize`, which bounds what is claimed at roughly twice what is used. `MetadataBlockSize` is therefore a ceiling, and must be positive for any placement that uses blocks.
- **The end-of-file address covers allocated rather than written space**, because an address can be referenced without ever being written to: a dataset declared through `BeginWrite` and never written has its payload allocated and named by its layout message. Under a clustered placement nothing extends the stream over it, and `h5dump` then reports *"invalid dataset size, likely file corruption"*. The stream is extended to the allocator's mark instead — translated by the base address, since the allocator counts from the superblock and the stream from the start of the file.
- Overlaps #179 only in `H5WriteOptions`, where both add a property to the record body; whichever lands second takes a one-line conflict.
- No `CHANGELOG.md` entry here, on the assumption you would rather write that yourself — happy to add one.

### Changes since the first review

Everything below came out of your two comments and of reviewing the result again afterwards.

- **`Interleaved` is the default**, as requested. The feature is now purely additive: files written with default options are byte-for-byte what they were.
- **The sizing pass no longer walks fixed-size data** — your suggestion, implemented; see the reply on that thread for the two corrections it needed.
- **Corrected the `BeginWrite` claim, twice.** It was never chunk indexes, and it is no longer variable-length data either. `NothingDeferredOutrunsTheSizingPass` asserts the shortfall is zero for all three.
- **Front loading now costs nothing.** The reservation added 12 kB of slack, justified on a reading of the superblock accounting that was backwards — it left the region long, not short. Subtracting instead makes it exact.
- **A dataset's variable-length values are no longer counted as structure.** They shared the global heap with attribute values, so a variable-length string dataset with no attributes measured 97.3% structure and a front-loaded region swallowed its payload. Now 0.0%.
- **Fixed a corruption bug of my own**: the extension above compared an allocator address against a stream length without translating for `UserBlockSize`, so a user block plus a never-written deferred dataset produced a file `h5dump` rejects.
- **Fixed a misclassification of my own**: the implicit chunk index, per the bullet above. Worth knowing that the measurements in the first version of this description therefore did not cover unfiltered chunked data.
- **Made three assertions able to fail.** `TestUtils.DumpH5File` strips h5dump's error stack so the fixture comparisons do not depend on the installed version — which also strips every trace of failure, so `DoesNotContain("error")` always passed. On `lzf.h5`, which h5dump rejects with exit code 1 and 2,910 bytes of error stack, the stripped output contains "error" zero times. There is now a `RunH5Dump` that reports the exit code, and it also returns null when h5dump is absent so that `Skip.If(dump is null)` skips instead of failing — it was dead code, and those tests failed on a machine without h5dump.
- **Reworked the `RangeReadCostTests` payload** from a strided integer ramp to a measurement series. The ramp is pathological for a fast match finder: .NET 9 replaced the bundled zlib with zlib-ng, and that shape compressed 73% worse there, moving every figure the test reports. The figures above now land within 0.2% on both runtimes with identical request counts — and the request count is now asserted rather than merely printed.
- **`MetadataBlockSize <= 0` and a negative `MetadataReservation` now throw** instead of silently turning `Aggregated` into `Interleaved`.
- Added a *Metadata placement* section to `doc/writing/index.md`, since the feature is opt-in and would otherwise only be discoverable from XML docs.

Two pre-existing issues turned up along the way, neither related to placement and neither touched here: #184 (deflate at `compression-level: 1` expands data on .NET 9+) and #183 (any `UserBlockSize` above 512 produces a file PureHDF cannot reopen). #183 is why the new `UserBlockSize` coverage uses 512 and no larger value.
