### PR TITLE
test(reading): run the same-file virtual dataset tests serially

### DIFF
--- a/tests/PureHDF.Tests/Reading/VirtualDatasetSameFileTests.cs
+++ b/tests/PureHDF.Tests/Reading/VirtualDatasetSameFileTests.cs
@@ -19,6 +19,12 @@ namespace PureHDF.Tests.Reading;
 /// process working directory - so it resolves them off the filesystem and says nothing about streams.
 /// </para>
 /// </remarks>
+/// <remarks>
+/// Opted into the shared-state collection because <c>TestUtils.PrepareTestFile</c> drives the HDF5 C
+/// library, whose file tracking is process-global. Left out, these tests fail intermittently against
+/// whatever else happens to be creating a file at the same moment.
+/// </remarks>
+[Collection(SharedHdf5StateCollection.Name)]
 public class VirtualDatasetSameFileTests
 {
     private static readonly int[] _expected =


### PR DESCRIPTION
`VirtualDatasetSameFileTests` prepares its files through `TestUtils.PrepareTestFile`, which drives the HDF5 C library, and that library's file tracking is process-global. Running the class in parallel with everything else therefore fails intermittently:

```
System.IO.IOException : The process cannot access the file '/tmp/tmpoCdT0D.tmp'
because it is being used by another process.
   at PureHDF.VOL.Native.NativeFile.InternalOpenAsync(...)
   at PureHDF.Tests.Reading.VirtualDatasetSameFileTests.CanReadAVirtualDatasetWhoseSourceIsInTheSameFile()
```

Both tests in the class hit it, and it reproduced in roughly 2 of 8 full-suite runs here on `dev`, on both `net8.0` and `net10.0`. Each one passes when the class is run on its own.

`[Collection(SharedHdf5StateCollection.Name)]` is what the other classes in this position already use — `H5MemoryDriverTests`, `H5MemoryMappedFileDriverTests`, `AsyncDatasetReadTests`, `AsyncRegionReferenceTests` and `FilterTests` all opt in. This class looks to have simply been missed.

Sent separately from #179 and #180 because it is unrelated to either, but worth landing first: until it does, it will flake in their CI runs too.
