### PR TITLE
fix(reading): bound how deeply a datatype may nest

### DIFF
--- a/src/PureHDF/API.Reading/H5ReadOptions.cs
+++ b/src/PureHDF/API.Reading/H5ReadOptions.cs
@@ -22,6 +22,17 @@ namespace PureHDF;
 /// of a single read pass, repeated reads degrade to re-decoding everything.
 /// </para>
 /// </param>
+/// <param name="MaxDatatypeNestingDepth">
+/// A value that indicates how deeply a datatype may nest before the file is rejected. The default value
+/// is 64.
+/// <para>
+/// A datatype message contains its base type inline - an array of a compound of a variable-length
+/// sequence - so decoding one is recursive, and the depth comes from the file being read. Without a
+/// bound, a file nesting deeply enough exhausts the stack, which terminates the process instead of
+/// raising an exception the caller could handle. Real datatypes nest a handful of levels, so the default
+/// sits far above anything a writer produces and far below the point where the stack runs out.
+/// </para>
+/// </param>
 public record H5ReadOptions(
     bool IncludeStructFields = true,
     bool IncludeStructProperties = false,
@@ -29,5 +40,6 @@ public record H5ReadOptions(
     bool IncludeClassProperties = true,
     Func<FieldInfo, string?>? FieldNameMapper = default,
     Func<PropertyInfo, string?>? PropertyNameMapper = default,
-    long GlobalHeapCacheByteBudget = 64 * 1024 * 1024
+    long GlobalHeapCacheByteBudget = 64 * 1024 * 1024,
+    int MaxDatatypeNestingDepth = 64
 );

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Attribute/AttributeMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Attribute/AttributeMessage.Reading.cs
@@ -70,7 +70,7 @@ internal partial record class AttributeMessage(
             : MessageFlags.NoFlags;
 
         var datatype = await Decode(context, objectHeaderAddress, flags1,
-            () => DatatypeMessage.Decode(context.Driver)).ConfigureAwait(false);
+            () => DatatypeMessage.Decode(context.Driver, context.ReadOptions.MaxDatatypeNestingDepth)).ConfigureAwait(false);
 
         if (version == 1)
         {

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypeMessage.Reading.cs
@@ -55,8 +55,26 @@ internal partial record class DatatypeMessage(
         }
     }
 
-    public static async ValueTask<DatatypeMessage> Decode(H5DriverBase driver)
+    /// <summary>
+    /// Decodes a datatype message, and the base types nested inside it.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="depth" /> counts how far the nesting has already descended, and is checked against
+    /// <see cref="H5ReadOptions.MaxDatatypeNestingDepth" /> on the way in. The recursion is driven by the
+    /// file, so an unbounded one exhausts the stack - which kills the process rather than raising something
+    /// a caller can catch.
+    /// </remarks>
+    public static async ValueTask<DatatypeMessage> Decode(
+        H5DriverBase driver,
+        int maxNestingDepth,
+        int depth = 0)
     {
+        if (depth > maxNestingDepth)
+            throw new NotSupportedException(
+                $"The datatype is nested more than {maxNestingDepth} levels deep. Increase "
+                + $"{nameof(H5ReadOptions)}.{nameof(H5ReadOptions.MaxDatatypeNestingDepth)} if the file is "
+                + "genuinely nested this deeply.");
+
         var classVersion = await driver.ReadByte().ConfigureAwait(false);
         var version = (byte)(classVersion >> 4);
         var @class = (DatatypeMessageClass)(classVersion & 0x0F);
@@ -98,10 +116,10 @@ internal partial record class DatatypeMessage(
                 DatatypeMessageClass.Time => await TimePropertyDescription.Decode(driver).ConfigureAwait(false),
                 DatatypeMessageClass.BitField => await BitFieldPropertyDescription.Decode(driver).ConfigureAwait(false),
                 DatatypeMessageClass.Opaque => await OpaquePropertyDescription.Decode(driver, ((OpaqueBitFieldDescription)bitField).TagByteLength).ConfigureAwait(false),
-                DatatypeMessageClass.Compound => await CompoundPropertyDescription.Decode(driver, version, size).ConfigureAwait(false),
-                DatatypeMessageClass.Enumerated => await EnumerationPropertyDescription.Decode(driver, version, size, ((EnumerationBitFieldDescription)bitField).MemberCount).ConfigureAwait(false),
-                DatatypeMessageClass.VariableLength => await VariableLengthPropertyDescription.Decode(driver).ConfigureAwait(false),
-                DatatypeMessageClass.Array => await ArrayPropertyDescription.Decode(driver, version).ConfigureAwait(false),
+                DatatypeMessageClass.Compound => await CompoundPropertyDescription.Decode(driver, version, size, maxNestingDepth, depth + 1).ConfigureAwait(false),
+                DatatypeMessageClass.Enumerated => await EnumerationPropertyDescription.Decode(driver, version, size, ((EnumerationBitFieldDescription)bitField).MemberCount, maxNestingDepth, depth + 1).ConfigureAwait(false),
+                DatatypeMessageClass.VariableLength => await VariableLengthPropertyDescription.Decode(driver, maxNestingDepth, depth + 1).ConfigureAwait(false),
+                DatatypeMessageClass.Array => await ArrayPropertyDescription.Decode(driver, version, maxNestingDepth, depth + 1).ConfigureAwait(false),
                 _ => throw new NotSupportedException($"The data type message '{@class}' is not supported.")
             };
 

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypePropertyDescriptions.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderMessages/Datatype/DatatypePropertyDescriptions.cs
@@ -18,7 +18,7 @@ internal record class ArrayPropertyDescription(
     : DatatypePropertyDescription
 {
     public static async ValueTask<ArrayPropertyDescription> Decode(
-        H5DriverBase driver, byte version)
+        H5DriverBase driver, byte version, int maxNestingDepth, int depth)
     {
         // rank
         var rank = await driver.ReadByte().ConfigureAwait(false);
@@ -47,7 +47,7 @@ internal record class ArrayPropertyDescription(
         }
 
         // base type
-        var baseType = await DatatypeMessage.Decode(driver).ConfigureAwait(false);
+        var baseType = await DatatypeMessage.Decode(driver, maxNestingDepth, depth).ConfigureAwait(false);
 
         return new ArrayPropertyDescription(
             Rank: rank,
@@ -102,7 +102,9 @@ internal record class CompoundPropertyDescription(
     public static async ValueTask<CompoundPropertyDescription> Decode(
         H5DriverBase driver,
         byte version,
-        uint valueSize)
+        uint valueSize,
+        int maxNestingDepth,
+        int depth)
     {
         string name;
         ulong memberByteOffset;
@@ -139,7 +141,7 @@ internal record class CompoundPropertyDescription(
                 }
 
                 // member type message
-                memberTypeMessage = await DatatypeMessage.Decode(driver).ConfigureAwait(false);
+                memberTypeMessage = await DatatypeMessage.Decode(driver, maxNestingDepth, depth).ConfigureAwait(false);
 
                 break;
 
@@ -152,7 +154,7 @@ internal record class CompoundPropertyDescription(
                 memberByteOffset = await driver.ReadUInt32().ConfigureAwait(false);
 
                 // member type message
-                memberTypeMessage = await DatatypeMessage.Decode(driver).ConfigureAwait(false);
+                memberTypeMessage = await DatatypeMessage.Decode(driver, maxNestingDepth, depth).ConfigureAwait(false);
 
                 break;
 
@@ -187,7 +189,7 @@ internal record class CompoundPropertyDescription(
                 }
 
                 // member type message
-                memberTypeMessage = await DatatypeMessage.Decode(driver).ConfigureAwait(false);
+                memberTypeMessage = await DatatypeMessage.Decode(driver, maxNestingDepth, depth).ConfigureAwait(false);
 
                 break;
 
@@ -251,10 +253,12 @@ internal record class EnumerationPropertyDescription(
         H5DriverBase driver,
         byte version,
         uint valueSize,
-        ushort memberCount)
+        ushort memberCount,
+        int maxNestingDepth,
+        int depth)
     {
         // base type
-        var baseType = await DatatypeMessage.Decode(driver).ConfigureAwait(false);
+        var baseType = await DatatypeMessage.Decode(driver, maxNestingDepth, depth).ConfigureAwait(false);
 
         // names
         var names = new string[memberCount];
@@ -459,10 +463,10 @@ internal record class VariableLengthPropertyDescription(
     : DatatypePropertyDescription
 {
     public static async ValueTask<VariableLengthPropertyDescription> Decode(
-        H5DriverBase driver)
+        H5DriverBase driver, int maxNestingDepth, int depth)
     {
         return new VariableLengthPropertyDescription(
-            BaseType: await DatatypeMessage.Decode(driver).ConfigureAwait(false)
+            BaseType: await DatatypeMessage.Decode(driver, maxNestingDepth, depth).ConfigureAwait(false)
         );
     }
 

--- a/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderPrefix/HeaderMessage.Reading.cs
+++ b/src/PureHDF/VOL/Native/FileFormat/Level2/ObjectHeaderPrefix/HeaderMessage.Reading.cs
@@ -82,7 +82,7 @@ internal readonly partial record struct HeaderMessage(
             MessageType.NIL => new NilMessage(),
             MessageType.Dataspace => await Message.Decode(context, objectHeaderAddress, flags, () => DataspaceMessage.Decode(context)).ConfigureAwait(false),
             MessageType.LinkInfo => await LinkInfoMessage.Decode(context).ConfigureAwait(false),
-            MessageType.Datatype => await Message.Decode(context, objectHeaderAddress, flags, () => DatatypeMessage.Decode(context.Driver)).ConfigureAwait(false),
+            MessageType.Datatype => await Message.Decode(context, objectHeaderAddress, flags, () => DatatypeMessage.Decode(context.Driver, context.ReadOptions.MaxDatatypeNestingDepth)).ConfigureAwait(false),
             MessageType.OldFillValue => await Message.Decode(context, objectHeaderAddress, flags, () => OldFillValueMessage.Decode(context.Driver)).ConfigureAwait(false),
             MessageType.FillValue => await Message.Decode(context, objectHeaderAddress, flags, () => FillValueMessage.Decode(context.Driver)).ConfigureAwait(false),
             MessageType.Link => await LinkMessage.Decode(context).ConfigureAwait(false),

--- a/tests/PureHDF.Tests/Reading/DatatypeMessageNestingTests.cs
+++ b/tests/PureHDF.Tests/Reading/DatatypeMessageNestingTests.cs
@@ -1,0 +1,162 @@
+using PureHDF.VFD;
+using Xunit;
+
+namespace PureHDF.Tests.Reading;
+
+/// <summary>
+/// A datatype message contains its base type inline, so decoding one is recursive - and the nesting depth
+/// comes from the file being read.
+/// </summary>
+/// <remarks>
+/// Without a bound, a file that nests deeply enough exhausts the stack. That is not a catchable failure:
+/// the runtime terminates the process on <c>StackOverflowException</c>, so a caller cannot defend itself
+/// against a malformed or hostile file the way it can against every other decoding error. The bound is
+/// <see cref="H5ReadOptions.MaxDatatypeNestingDepth" />, so a file that genuinely nests further can still
+/// be read.
+/// </remarks>
+public class DatatypeMessageNestingTests
+{
+    /// <summary>
+    /// A variable-length datatype message, whose base type is whatever follows it. Eight bytes per level:
+    /// the class/version byte, three bytes of class bit field, and the four-byte size.
+    /// </summary>
+    private static void WriteVariableLengthLevel(BinaryWriter writer)
+    {
+        writer.Write((byte)(1 << 4 | (byte)DatatypeMessageClass.VariableLength));
+        writer.Write((byte)(byte)InternalVariableLengthType.Sequence);
+        writer.Write((byte)0);
+        writer.Write((byte)0);
+        writer.Write((uint)16);
+    }
+
+    /// <summary>A one-byte unsigned fixed-point type, to terminate the nesting.</summary>
+    private static void WriteFixedPointTerminator(BinaryWriter writer)
+    {
+        writer.Write((byte)(1 << 4 | (byte)DatatypeMessageClass.FixedPoint));
+        writer.Write((byte)0);
+        writer.Write((byte)0);
+        writer.Write((byte)0);
+        writer.Write((uint)1);
+        writer.Write((ushort)0);
+        writer.Write((ushort)8);
+    }
+
+    private static H5DriverBase DriverForNesting(int levels)
+    {
+        var stream = new MemoryStream();
+        var writer = new BinaryWriter(stream);
+
+        for (int i = 0; i < levels; i++)
+            WriteVariableLengthLevel(writer);
+
+        WriteFixedPointTerminator(writer);
+
+        writer.Flush();
+        stream.Seek(0, SeekOrigin.Begin);
+
+        return new H5StreamDriver(stream, leaveOpen: false);
+    }
+
+    /// <summary>
+    /// Nesting a real file could plausibly use keeps working. A compound of arrays of compounds is a few
+    /// levels deep; nothing legitimate approaches the bound.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(32)]
+    public void ADatatypeNestedToAReasonableDepthDecodes(int levels)
+    {
+        // Arrange
+        using var driver = DriverForNesting(levels);
+
+        // Act
+        var message = DatatypeMessage
+            .Decode(driver, new H5ReadOptions().MaxDatatypeNestingDepth)
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert
+        var depth = 0;
+
+        while (message.Class == DatatypeMessageClass.VariableLength)
+        {
+            depth++;
+            message = ((VariableLengthPropertyDescription)message.Properties[0]).BaseType;
+        }
+
+        Assert.Equal(levels, depth);
+        Assert.Equal(DatatypeMessageClass.FixedPoint, message.Class);
+    }
+
+    /// <summary>
+    /// Past the bound it reports the file as unsupported, which a caller can catch - rather than recursing
+    /// until the stack runs out, which no caller can.
+    /// </summary>
+    [Theory]
+    [InlineData(1_000)]
+    [InlineData(100_000)]
+    public void ADatatypeNestedTooDeeplyThrowsInsteadOfExhaustingTheStack(int levels)
+    {
+        // Arrange
+        using var driver = DriverForNesting(levels);
+
+        // Act
+        void action() => DatatypeMessage
+            .Decode(driver, new H5ReadOptions().MaxDatatypeNestingDepth)
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert
+        var exception = Assert.Throws<NotSupportedException>(action);
+        Assert.Contains(nameof(H5ReadOptions.MaxDatatypeNestingDepth), exception.Message);
+    }
+
+    /// <summary>
+    /// The bound is the caller's to set, so a file that genuinely nests further can still be read - which
+    /// is what keeps the default from being a limit on what PureHDF can open.
+    /// </summary>
+    [Fact]
+    public void TheBoundCanBeRaised()
+    {
+        // Arrange
+        var levels = new H5ReadOptions().MaxDatatypeNestingDepth + 10;
+
+        using var refused = DriverForNesting(levels);
+        using var allowed = DriverForNesting(levels);
+
+        // Act
+        void tooDeep() => DatatypeMessage
+            .Decode(refused, new H5ReadOptions().MaxDatatypeNestingDepth)
+            .GetAwaiter()
+            .GetResult();
+
+        var message = DatatypeMessage
+            .Decode(allowed, new H5ReadOptions(MaxDatatypeNestingDepth: levels).MaxDatatypeNestingDepth)
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert
+        Assert.Throws<NotSupportedException>(tooDeep);
+        Assert.Equal(DatatypeMessageClass.VariableLength, message.Class);
+    }
+
+    /// <summary>
+    /// Lowering it works too, so a caller reading untrusted files can be stricter than the default.
+    /// </summary>
+    [Fact]
+    public void TheBoundCanBeLowered()
+    {
+        // Arrange
+        using var driver = DriverForNesting(8);
+
+        // Act
+        void action() => DatatypeMessage
+            .Decode(driver, new H5ReadOptions(MaxDatatypeNestingDepth: 4).MaxDatatypeNestingDepth)
+            .GetAwaiter()
+            .GetResult();
+
+        // Assert
+        Assert.Throws<NotSupportedException>(action);
+    }
+}


### PR DESCRIPTION
Decoding a datatype message is recursive: the message contains its base type inline, and `DatatypeMessage.Decode` descends into it from six places in `DatatypePropertyDescriptions.cs` — an array's base type, a compound's members, an enumeration's base type and a variable-length sequence's. Nothing bounded that recursion, and the depth is read from the file.

A file that nests deeply enough therefore exhausts the stack. That is the one decoding failure a caller cannot handle: the runtime terminates the process on `StackOverflowException`, where every other malformed input raises something catchable, so wrapping `H5File.OpenRead` in a `try`/`catch` is no defence. Around 1500 levels sufficed on my machine, though the exact depth depends on the stack the reader happens to run on. The nesting need not even be invalid — a well-formed chain of variable-length sequences costs 8 bytes per level, so under 16 kB of file is enough.

`H5ReadOptions.MaxDatatypeNestingDepth` now bounds it, defaulting to 64. That is far above the handful of levels a real datatype composes — a compound of arrays of compounds — and far below where the stack runs out. Exceeding it throws `NotSupportedException` naming the option, so a file that genuinely nests further can still be read by raising the bound, and a caller reading untrusted files can lower it.

The bound and the current depth are threaded through `DatatypeMessage.Decode` and the four recursing property decoders, with the check in one place on the way in. The two entry points supply it from `context.ReadOptions`.

### Worth flagging

- **`H5ReadOptions` gains a constructor parameter**, so the record's constructor and `Deconstruct` signatures change. Source-compatible — the parameter is last and optional — but an assembly compiled against the previous version needs recompiling.
- **The default is a policy choice.** 64 is generous for composed datatypes but it is a cap where there was none, so a file nesting deeper than 64 that previously decoded will now be refused until the option is raised. I could not construct such a file with PureHDF's own writer, and did not find one in the test corpus.
- The limit is deliberately not derived from where the stack actually runs out, since that varies with stack size and build configuration.

Found while investigating the object header message size limit in #179 — one of the corrupt files that bug produced happened to decode into deep nesting — but the two are independent, and this reaches any malformed file rather than anything PureHDF writes.
