### PR TITLE
fix(reading): probe absolute offsets when searching for the superblock

### DIFF
--- a/src/PureHDF/VOL/Native/API.Reading/NativeFile.cs
+++ b/src/PureHDF/VOL/Native/API.Reading/NativeFile.cs
@@ -131,19 +131,21 @@ public class NativeFile : NativeGroup, IDisposable
         if (!BitConverter.IsLittleEndian)
             throw new Exception("This library only works on little endian systems.");
 
-        // superblock
-        var stepSize = 512;
+        // superblock: the format allows a user block in front of it, so the superblock starts at
+        // offset 0, 512, 1024, 2048, ... - each candidate is an absolute offset, not a distance
+        // from the previous one.
+        var offset = 0L;
         var signature = await driver.ReadBytes(8).ConfigureAwait(false);
 
         while (!ValidateSignature(signature, Superblock.Signature))
         {
-            driver.Seek(stepSize - 8, SeekOrigin.Current);
+            offset = offset == 0 ? 512 : offset * 2;
 
-            if (driver.Position >= driver.Length)
+            if (offset + 8 > driver.Length)
                 throw new Exception("The file is not a valid HDF 5 file.");
 
+            driver.Seek(offset, SeekOrigin.Begin);
             signature = await driver.ReadBytes(8).ConfigureAwait(false);
-            stepSize *= 2;
         }
 
         var version = await driver.ReadByte().ConfigureAwait(false);

--- a/tests/PureHDF.Tests/Writing/MiscTests.cs
+++ b/tests/PureHDF.Tests/Writing/MiscTests.cs
@@ -109,4 +109,40 @@ public class MiscTests
                 File.Delete(filePath);
         }
     }
+
+    [Theory]
+    [InlineData(0UL)]
+    [InlineData(512UL)]
+    [InlineData(1024UL)]
+    [InlineData(2048UL)]
+    [InlineData(4096UL)]
+    public void CanRoundTrip_WithUserBlock(ulong userBlockSize)
+    {
+        // Arrange
+        var expected = Enumerable.Range(0, 4096).ToArray();
+
+        var file = new H5File
+        {
+            ["d"] = expected
+        };
+
+        var filePath = Path.GetTempFileName();
+
+        // Act
+        file.Write(filePath, new H5WriteOptions { UserBlockSize = userBlockSize });
+
+        // Assert
+        try
+        {
+            using var actualFile = H5File.OpenRead(filePath);
+            var actual = actualFile.Dataset("d").Read<int[]>();
+
+            Assert.Equal(expected, actual);
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #183.

A file written with `UserBlockSize` above 512 could not be reopened: `NativeFile.InternalOpenAsync` advanced by a doubling delta relative to the current position, so after the 512 candidate it probed 1536, 3584, 7680, … instead of 1024, 2048, 4096, …. h5dump read the same files fine, so only the reader was affected.

The search now seeks to each candidate offset absolutely. The bounds check moved with it: it rejects an offset that cannot hold the 8-byte signature, rather than testing the position after a seek that may already be past the end.

## Test plan

`CanRoundTrip_WithUserBlock` in `Writing/MiscTests.cs` writes and reads back a 4,096-element `int` dataset for user block sizes 0, 512, 1024, 2048 and 4096. Before the fix the last three throw "The file is not a valid HDF 5 file."; all five pass after it. Full suite green on net8.0 (no .NET 6 runtime available here, so net6.0 was not exercised).

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)